### PR TITLE
feat: dynamic content templates for ability-cards and skill-cards

### DIFF
--- a/dev/dnd-ui-dev/Generic/Ability Cards.md
+++ b/dev/dnd-ui-dev/Generic/Ability Cards.md
@@ -1,6 +1,47 @@
+---
+agility: 14
+strength: 18
+finesse: 16
+resolve: 12
+intuition: 10
+presence: 8
+---
+
 # Ability Cards (Raw)
 
 Tests the `ability-cards` code block which renders raw card data without automatic modifier calculation. Unlike the `ability` block, this takes pre-computed values directly — useful for non-5e systems or custom stats.
+
+## Dynamic Content
+
+Ability cards with values driven by frontmatter. Change the frontmatter values above to verify cards update reactively.
+
+```ability-cards
+items:
+  - label: Agility
+    label_short: AGI
+    header_value: '{{ frontmatter.agility }}'
+    value: '+{{ floor (divide (subtract frontmatter.agility 10) 2) }}'
+  - label: Strength
+    label_short: STR
+    header_value: '{{ frontmatter.strength }}'
+    value: '+{{ floor (divide (subtract frontmatter.strength 10) 2) }}'
+  - label: Finesse
+    label_short: FIN
+    header_value: '{{ frontmatter.finesse }}'
+    value: '+{{ floor (divide (subtract frontmatter.finesse 10) 2) }}'
+  - label: Resolve
+    label_short: RES
+    header_value: '{{ frontmatter.resolve }}'
+    value: '+{{ floor (divide (subtract frontmatter.resolve 10) 2) }}'
+  - label: Intuition
+    label_short: INT
+    header_value: '{{ frontmatter.intuition }}'
+    value: '+{{ floor (divide (subtract frontmatter.intuition 10) 2) }}'
+  - label: Presence
+    label_short: PRE
+    header_value: '{{ frontmatter.presence }}'
+    value: '+{{ floor (divide (subtract frontmatter.presence 10) 2) }}'
+```
 
 ## Pathfinder 2e Attributes
 

--- a/dev/dnd-ui-dev/Generic/Skill Cards.md
+++ b/dev/dnd-ui-dev/Generic/Skill Cards.md
@@ -1,6 +1,57 @@
+---
+arcana_mod: 5
+stealth_mod: 4
+athletics_mod: 2
+perception_mod: 3
+prof_bonus: 3
+---
+
 # Skill Cards (Raw)
 
 Tests the `skill-cards` code block which renders raw skill data without automatic calculation. Unlike the `skills` block, this takes pre-computed modifier values and explicit proficiency levels.
+
+## Dynamic Content
+
+Skill cards with modifiers driven by frontmatter. Change the frontmatter values above to verify cards update reactively.
+
+```skill-cards
+items:
+  - label: Arcana
+    ability: INT
+    modifier: '{{ frontmatter.arcana_mod }}'
+    proficiency: proficient
+  - label: Stealth
+    ability: DEX
+    modifier: '{{ frontmatter.stealth_mod }}'
+    proficiency: expert
+  - label: Athletics
+    ability: STR
+    modifier: '{{ frontmatter.athletics_mod }}'
+  - label: Perception
+    ability: WIS
+    modifier: '{{ frontmatter.perception_mod }}'
+    proficiency: proficient
+```
+
+## Dynamic Content with Math
+
+Skill modifiers computed using math helpers and frontmatter values.
+
+```skill-cards
+items:
+  - label: Arcana (Prof)
+    ability: INT
+    modifier: '{{ add frontmatter.arcana_mod frontmatter.prof_bonus }}'
+    proficiency: proficient
+  - label: Stealth (Expert)
+    ability: DEX
+    modifier: '{{ add frontmatter.stealth_mod (multiply frontmatter.prof_bonus 2) }}'
+    proficiency: expert
+  - label: Athletics (Half)
+    ability: STR
+    modifier: '{{ add frontmatter.athletics_mod (floor (divide frontmatter.prof_bonus 2)) }}'
+    proficiency: half
+```
 
 ## Mixed Proficiency Levels
 

--- a/docs/components/ability-cards.md
+++ b/docs/components/ability-cards.md
@@ -1,6 +1,6 @@
 # Ability Cards
 
-Ability Cards are a headless, system-agnostic card component for displaying ability-style data. Each card shows a label, a value, and an optional sublabel. No frontmatter integration or modifier calculation is performed — you supply the exact values to display.
+Ability Cards are a headless, system-agnostic card component for displaying ability-style data. Each card shows a label, a value, and an optional sublabel. No automatic modifier calculation is performed — you supply the exact values to display. All text properties support [dynamic content](/concepts/dynamic-content) templates for frontmatter integration and calculations.
 
 ::: info System-Agnostic Components
 System-agnostic component support is limited but will continue to improve in future releases. Join the [discussion on GitHub](https://github.com/hay-kot/obsidian-dnd-ui-toolkit/discussions/56) to share feedback and ideas.
@@ -9,7 +9,7 @@ System-agnostic component support is limited but will continue to improve in fut
 ::: tip When to use Ability Cards vs. D&D 5e Ability Scores
 The [D&D 5e Ability Scores](/character-sheet/ability-scores) block integrates with frontmatter, automatically calculates modifiers from raw scores, and supports proficiency and bonuses for saving throws. Use it when you want full D&D 5e ability score mechanics.
 
-**Ability Cards** display whatever values you provide with no calculations or frontmatter dependency. Use them when you want full control over what is shown, or when working outside D&D 5e.
+**Ability Cards** display whatever values you provide with no automatic calculations. They support [dynamic content](/concepts/dynamic-content) templates for pulling values from frontmatter and performing calculations. Use them when you want full control over what is shown, or when working outside D&D 5e.
 :::
 
 <DaggerHeartAbilityDemo />
@@ -64,8 +64,43 @@ items:
 
 | Property       | Type          | Default | Description                                                    |
 | -------------- | ------------- | ------- | -------------------------------------------------------------- |
-| `label`        | String        | —       | The main label for the card                                    |
-| `label_short`  | String        | —       | Optional abbreviated label displayed in the card header        |
-| `header_value` | Number        | —       | Optional value displayed in the header next to the label       |
-| `value`        | String/Number | —       | The primary value to display (large, centered)                 |
-| `sublabel`     | String        | —       | Optional additional text below the value                       |
+| `label` †      | String        | —       | The main label for the card                                    |
+| `label_short` †| String        | —       | Optional abbreviated label displayed in the card header        |
+| `header_value` †| Number       | —       | Optional value displayed in the header next to the label       |
+| `value` †      | String/Number | —       | The primary value to display (large, centered)                 |
+| `sublabel` †   | String        | —       | Optional additional text below the value                       |
+
+† Supports [dynamic content](/concepts/dynamic-content) templates
+
+## Dynamic Content Example
+
+::: v-pre
+Use frontmatter values to drive ability card display. When frontmatter changes, the cards update automatically.
+
+```yaml
+---
+agility: 14
+strength: 12
+finesse: 16
+---
+```
+
+````yaml
+```ability-cards
+items:
+  - label: Agility
+    label_short: AGI
+    header_value: '{{ frontmatter.agility }}'
+    value: '+{{ floor (divide (subtract frontmatter.agility 10) 2) }}'
+  - label: Strength
+    label_short: STR
+    header_value: '{{ frontmatter.strength }}'
+    value: '+{{ floor (divide (subtract frontmatter.strength 10) 2) }}'
+  - label: Finesse
+    label_short: FIN
+    header_value: '{{ frontmatter.finesse }}'
+    value: '+{{ floor (divide (subtract frontmatter.finesse 10) 2) }}'
+```
+````
+
+:::

--- a/docs/components/skill-cards.md
+++ b/docs/components/skill-cards.md
@@ -1,6 +1,6 @@
 # Skill Cards
 
-Skill Cards are a headless, system-agnostic card component for displaying skill-style data. Each card shows a label, an ability tag, a modifier value, and an optional proficiency level. No frontmatter integration or automatic modifier calculation is performed — you supply the exact values to display.
+Skill Cards are a headless, system-agnostic card component for displaying skill-style data. Each card shows a label, an ability tag, a modifier value, and an optional proficiency level. No automatic modifier calculation is performed — you supply the exact values to display. All text and numeric properties support [dynamic content](/concepts/dynamic-content) templates for frontmatter integration and calculations.
 
 ::: info System-Agnostic Components
 System-agnostic component support is limited but will continue to improve in future releases. Join the [discussion on GitHub](https://github.com/hay-kot/obsidian-dnd-ui-toolkit/discussions/56) to share feedback and ideas.
@@ -9,7 +9,7 @@ System-agnostic component support is limited but will continue to improve in fut
 ::: tip When to use Skill Cards vs. D&D 5e Skills
 The [D&D 5e Skills](/character-sheet/skills) block integrates with frontmatter and automatically calculates skill modifiers from your ability scores, proficiency bonus, and any bonuses you define. Use it when you want full D&D 5e skill mechanics.
 
-**Skill Cards** display whatever values you provide with no calculations or frontmatter dependency. Use them when you want full control over what is shown, or when working outside D&D 5e.
+**Skill Cards** display whatever values you provide with no automatic calculations. They support [dynamic content](/concepts/dynamic-content) templates for pulling values from frontmatter and performing calculations. Use them when you want full control over what is shown, or when working outside D&D 5e.
 :::
 
 <DaggerHeartSkillDemo />
@@ -67,7 +67,42 @@ items:
 
 | Property      | Type   | Default | Description                                                                         |
 | ------------- | ------ | ------- | ----------------------------------------------------------------------------------- |
-| `label`       | String | —       | The skill name to display                                                           |
-| `ability`     | String | —       | The associated ability (e.g. Wis, Dex, Str)                                         |
-| `modifier`    | Number | —       | The modifier value to display                                                       |
+| `label` †     | String | —       | The skill name to display                                                           |
+| `ability` †   | String | —       | The associated ability (e.g. Wis, Dex, Str)                                         |
+| `modifier` †  | Number | —       | The modifier value to display                                                       |
 | `proficiency` | String | —       | Proficiency level: `"proficient"`, `"expert"`, `"half"`, or omit for no proficiency |
+
+† Supports [dynamic content](/concepts/dynamic-content) templates
+
+## Dynamic Content Example
+
+::: v-pre
+Use frontmatter values to drive skill card display. When frontmatter changes, the cards update automatically.
+
+```yaml
+---
+arcana_mod: 4
+blade_mod: 3
+codex_mod: 5
+---
+```
+
+````yaml
+```skill-cards
+items:
+  - label: Arcana
+    ability: Knowledge
+    modifier: '{{ frontmatter.arcana_mod }}'
+    proficiency: proficient
+  - label: Blade
+    ability: Strength
+    modifier: '{{ frontmatter.blade_mod }}'
+    proficiency: proficient
+  - label: Codex
+    ability: Knowledge
+    modifier: '{{ frontmatter.codex_mod }}'
+    proficiency: expert
+```
+````
+
+:::

--- a/lib/utils/template.test.ts
+++ b/lib/utils/template.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { hasTemplateVariables, processTemplate, createTemplateContext } from "./template";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { coerceNumericTemplate, hasTemplateVariables, processTemplate, createTemplateContext } from "./template";
 import { calculateModifier } from "lib/domains/abilities";
 import type { TemplateContext } from "./template";
 
@@ -59,6 +59,57 @@ describe("template", () => {
 
     it("should return original text when no template variables", () => {
       expect(processTemplate("No templates here", mockContext)).toBe("No templates here");
+    });
+  });
+
+  describe("coerceNumericTemplate", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("returns the parsed number for valid numeric input", () => {
+      expect(coerceNumericTemplate("5", "5")).toBe(5);
+      expect(coerceNumericTemplate("-3", "-3")).toBe(-3);
+      expect(coerceNumericTemplate("0", "0")).toBe(0);
+      expect(coerceNumericTemplate(" 12 ", " 12 ")).toBe(12);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 silently for non-numeric raw input (no template)", () => {
+      expect(coerceNumericTemplate("abc", "abc")).toBe(0);
+      expect(coerceNumericTemplate("", "")).toBe(0);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns when a templated source resolves to a non-numeric value", () => {
+      expect(coerceNumericTemplate("abc", "{{ frontmatter.foo }}")).toBe(0);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain("did not resolve to a number");
+      expect(warnSpy.mock.calls[0][0]).toContain("{{ frontmatter.foo }}");
+    });
+
+    it("warns when a templated source resolves to an empty string (missing property)", () => {
+      expect(coerceNumericTemplate("", "{{ frontmatter.missing }}")).toBe(0);
+      expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it("warns when a malformed template falls back to the raw source string", () => {
+      // processTemplate returns the original text when Handlebars compile fails,
+      // so the processed value here still contains the template delimiters.
+      const malformed = "{{#if}}foo{{/if}}";
+      expect(coerceNumericTemplate(malformed, malformed)).toBe(0);
+      expect(warnSpy).toHaveBeenCalledOnce();
+    });
+
+    it("does not warn when the templated source resolves to a number", () => {
+      expect(coerceNumericTemplate("7", "{{ frontmatter.bonus }}")).toBe(7);
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -54,6 +54,25 @@ export function processTemplate(text: string, context: TemplateContext): string 
   }
 }
 
+/**
+ * Coerces a (possibly template-processed) string into a number for numeric component
+ * fields. Falls back to 0 when the value is not numeric. If the original source
+ * contained template variables, a typo or compile failure can leave the result empty
+ * or non-numeric — in that case we emit a console.warn so the failure leaves a
+ * breadcrumb instead of silently rendering as 0.
+ */
+export function coerceNumericTemplate(processed: string, source: string): number {
+  const trimmed = processed.trim();
+  const n = Number(trimmed);
+  if (trimmed !== "" && Number.isFinite(n)) return n;
+  if (hasTemplateVariables(source)) {
+    console.warn(
+      `[dnd-ui-toolkit] Template did not resolve to a number: ${JSON.stringify(processed)} (from ${JSON.stringify(source)})`
+    );
+  }
+  return 0;
+}
+
 export function createTemplateContext(el: HTMLElement, fileContext: FileContext): TemplateContext {
   const frontmatter = fileContext.frontmatter();
 

--- a/lib/views/BadgesView.ts
+++ b/lib/views/BadgesView.ts
@@ -1,12 +1,10 @@
 import { BaseView } from "./BaseView";
 import BadgesRow from "../components/BadgesRow.vue";
-import { App, MarkdownPostProcessorContext } from "obsidian";
+import { MarkdownPostProcessorContext } from "obsidian";
 import { BadgeItem, BadgesBlock } from "lib/types";
-import { parse } from "yaml";
-import { hasTemplateVariables, processTemplate, createTemplateContext, TemplateContext } from "../utils/template";
-import { FileContext, useFileContext } from "./filecontext";
-import { VueMarkdown } from "./VueMarkdown";
+import { hasTemplateVariables, processTemplate } from "../utils/template";
 import StatCards from "../components/StatCards.vue";
+import { TemplateAwareComponent } from "./TemplateAwareComponent";
 
 export class StatsView extends BaseView {
   public codeblock = "stats";
@@ -27,38 +25,17 @@ export class BadgesView extends BaseView {
   }
 }
 
-class StatsLikeComponent extends VueMarkdown {
+class StatsLikeComponent extends TemplateAwareComponent {
   layout: "badges" | "cards" = "badges";
-  ctx: FileContext;
-  source: string;
-  isTemplate: boolean;
 
-  constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
-    super(el);
-    this.source = source;
-    this.ctx = useFileContext(app, ctx);
-  }
-
-  async onload() {
-    this.setupListeners();
-    this.processAndRender();
-  }
-
-  private processAndRender() {
-    const parsed = parse(this.source);
+  protected processAndRender() {
+    const parsed = this.parseSource();
     const items = Array.isArray(parsed.items) ? parsed.items : [];
     const grid = parsed.grid || {};
 
-    const hasTemplates = items.some(
-      (item: Partial<BadgeItem>) =>
-        hasTemplateVariables(String(item.label || "")) || hasTemplateVariables(String(item.value || ""))
+    const templateContext = this.detectTemplates(
+      items.flatMap((item: Partial<BadgeItem>) => [String(item.label || ""), String(item.value || "")])
     );
-
-    let templateContext: TemplateContext | null = null;
-    if (hasTemplates) {
-      templateContext = createTemplateContext(this.containerEl, this.ctx);
-      this.isTemplate = true;
-    }
 
     const badgesBlock: BadgesBlock = {
       items: items.map((item: Partial<BadgeItem>) => {
@@ -67,15 +44,9 @@ class StatsLikeComponent extends VueMarkdown {
         let sublabel = String(item.sublabel || "");
 
         if (templateContext) {
-          if (hasTemplateVariables(label)) {
-            label = processTemplate(label, templateContext);
-          }
-          if (hasTemplateVariables(value)) {
-            value = processTemplate(value, templateContext);
-          }
-          if (hasTemplateVariables(sublabel)) {
-            sublabel = processTemplate(sublabel, templateContext);
-          }
+          if (hasTemplateVariables(label)) label = processTemplate(label, templateContext);
+          if (hasTemplateVariables(value)) value = processTemplate(value, templateContext);
+          if (hasTemplateVariables(sublabel)) sublabel = processTemplate(sublabel, templateContext);
         }
 
         return {
@@ -96,21 +67,5 @@ class StatsLikeComponent extends VueMarkdown {
     } else if (this.layout === "cards") {
       this.mount(StatCards, { items: badgesBlock.items, grid: badgesBlock.grid, dense: badgesBlock.dense });
     }
-  }
-
-  private setupListeners() {
-    this.addUnloadFn(
-      this.ctx.onFrontmatterChange((_) => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
-
-    this.addUnloadFn(
-      this.ctx.onAbilitiesChange(() => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
   }
 }

--- a/lib/views/BadgesView.ts
+++ b/lib/views/BadgesView.ts
@@ -2,7 +2,7 @@ import { BaseView } from "./BaseView";
 import BadgesRow from "../components/BadgesRow.vue";
 import { MarkdownPostProcessorContext } from "obsidian";
 import { BadgeItem, BadgesBlock } from "lib/types";
-import { hasTemplateVariables, processTemplate } from "../utils/template";
+import { processTemplate } from "../utils/template";
 import StatCards from "../components/StatCards.vue";
 import { TemplateAwareComponent } from "./TemplateAwareComponent";
 
@@ -33,20 +33,24 @@ class StatsLikeComponent extends TemplateAwareComponent {
     const items = Array.isArray(parsed.items) ? parsed.items : [];
     const grid = parsed.grid || {};
 
-    const templateContext = this.detectTemplates(
-      items.flatMap((item: Partial<BadgeItem>) => [String(item.label || ""), String(item.value || "")])
+    const templateContext = this.setupTemplates(
+      items.flatMap((item: Partial<BadgeItem>) => [
+        String(item.label ?? ""),
+        String(item.value ?? ""),
+        String(item.sublabel ?? ""),
+      ])
     );
 
     const badgesBlock: BadgesBlock = {
       items: items.map((item: Partial<BadgeItem>) => {
-        let label = String(item.label || "");
-        let value = String(item.value || "");
-        let sublabel = String(item.sublabel || "");
+        let label = String(item.label ?? "");
+        let value = String(item.value ?? "");
+        let sublabel = String(item.sublabel ?? "");
 
         if (templateContext) {
-          if (hasTemplateVariables(label)) label = processTemplate(label, templateContext);
-          if (hasTemplateVariables(value)) value = processTemplate(value, templateContext);
-          if (hasTemplateVariables(sublabel)) sublabel = processTemplate(sublabel, templateContext);
+          label = processTemplate(label, templateContext);
+          value = processTemplate(value, templateContext);
+          sublabel = processTemplate(sublabel, templateContext);
         }
 
         return {

--- a/lib/views/RawAbilityView.ts
+++ b/lib/views/RawAbilityView.ts
@@ -1,10 +1,8 @@
 import { BaseView } from "./BaseView";
-import { VueMarkdown } from "./VueMarkdown";
 import AbilityCards from "../components/AbilityCards.vue";
-import { App, MarkdownPostProcessorContext } from "obsidian";
-import { parse } from "yaml";
-import { hasTemplateVariables, processTemplate, createTemplateContext, TemplateContext } from "../utils/template";
-import { FileContext, useFileContext } from "./filecontext";
+import { MarkdownPostProcessorContext } from "obsidian";
+import { hasTemplateVariables, processTemplate } from "../utils/template";
+import { TemplateAwareComponent } from "./TemplateAwareComponent";
 
 export class RawAbilityView extends BaseView {
   public codeblock = "ability-cards";
@@ -15,40 +13,20 @@ export class RawAbilityView extends BaseView {
   }
 }
 
-class RawAbilityComponent extends VueMarkdown {
-  ctx: FileContext;
-  source: string;
-  isTemplate = false;
-
-  constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
-    super(el);
-    this.source = source;
-    this.ctx = useFileContext(app, ctx);
-  }
-
-  async onload() {
-    this.setupListeners();
-    this.processAndRender();
-  }
-
-  private processAndRender() {
-    const parsed = parse(this.source);
+class RawAbilityComponent extends TemplateAwareComponent {
+  protected processAndRender() {
+    const parsed = this.parseSource();
     const items = Array.isArray(parsed?.items) ? parsed.items : [];
 
-    const hasTemplates = items.some(
-      (item: any) =>
-        hasTemplateVariables(String(item.label || "")) ||
-        hasTemplateVariables(String(item.label_short || "")) ||
-        hasTemplateVariables(String(item.header_value || "")) ||
-        hasTemplateVariables(String(item.value || "")) ||
-        hasTemplateVariables(String(item.sublabel || ""))
+    const templateContext = this.detectTemplates(
+      items.flatMap((item: any) => [
+        String(item.label || ""),
+        String(item.label_short || ""),
+        String(item.header_value || ""),
+        String(item.value || ""),
+        String(item.sublabel || ""),
+      ])
     );
-
-    let templateContext: TemplateContext | null = null;
-    if (hasTemplates) {
-      templateContext = createTemplateContext(this.containerEl, this.ctx);
-      this.isTemplate = true;
-    }
 
     const abilities = items.map((item: any) => {
       let label = String(item.label || "");
@@ -76,21 +54,5 @@ class RawAbilityComponent extends VueMarkdown {
     });
 
     this.mount(AbilityCards, { abilities, showSavingPrefix: false });
-  }
-
-  private setupListeners() {
-    this.addUnloadFn(
-      this.ctx.onFrontmatterChange(() => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
-
-    this.addUnloadFn(
-      this.ctx.onAbilitiesChange(() => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
   }
 }

--- a/lib/views/RawAbilityView.ts
+++ b/lib/views/RawAbilityView.ts
@@ -1,25 +1,96 @@
 import { BaseView } from "./BaseView";
 import { VueMarkdown } from "./VueMarkdown";
 import AbilityCards from "../components/AbilityCards.vue";
-import { MarkdownPostProcessorContext } from "obsidian";
+import { App, MarkdownPostProcessorContext } from "obsidian";
 import { parse } from "yaml";
+import { hasTemplateVariables, processTemplate, createTemplateContext, TemplateContext } from "../utils/template";
+import { FileContext, useFileContext } from "./filecontext";
 
 export class RawAbilityView extends BaseView {
   public codeblock = "ability-cards";
 
   public render(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext): void {
-    const parsed = parse(source);
-    const items = (parsed?.items || []).map((item: any) => ({
-      label: item.label || "",
-      labelShort: item.label_short || "",
-      total: item.header_value || 0,
-      modifier: item.value || "",
-      isProficient: false,
-      savingThrow: item.sublabel || "",
-    }));
+    const cmp = new RawAbilityComponent(el, source, this.app, ctx);
+    ctx.addChild(cmp);
+  }
+}
 
-    const child = new VueMarkdown(el);
-    child.mount(AbilityCards, { abilities: items, showSavingPrefix: false });
-    ctx.addChild(child);
+class RawAbilityComponent extends VueMarkdown {
+  ctx: FileContext;
+  source: string;
+  isTemplate = false;
+
+  constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
+    super(el);
+    this.source = source;
+    this.ctx = useFileContext(app, ctx);
+  }
+
+  async onload() {
+    this.setupListeners();
+    this.processAndRender();
+  }
+
+  private processAndRender() {
+    const parsed = parse(this.source);
+    const items = Array.isArray(parsed?.items) ? parsed.items : [];
+
+    const hasTemplates = items.some(
+      (item: any) =>
+        hasTemplateVariables(String(item.label || "")) ||
+        hasTemplateVariables(String(item.label_short || "")) ||
+        hasTemplateVariables(String(item.header_value || "")) ||
+        hasTemplateVariables(String(item.value || "")) ||
+        hasTemplateVariables(String(item.sublabel || ""))
+    );
+
+    let templateContext: TemplateContext | null = null;
+    if (hasTemplates) {
+      templateContext = createTemplateContext(this.containerEl, this.ctx);
+      this.isTemplate = true;
+    }
+
+    const abilities = items.map((item: any) => {
+      let label = String(item.label || "");
+      let labelShort = String(item.label_short || "");
+      let headerValue = String(item.header_value || "0");
+      let value = String(item.value || "");
+      let sublabel = String(item.sublabel || "");
+
+      if (templateContext) {
+        if (hasTemplateVariables(label)) label = processTemplate(label, templateContext);
+        if (hasTemplateVariables(labelShort)) labelShort = processTemplate(labelShort, templateContext);
+        if (hasTemplateVariables(headerValue)) headerValue = processTemplate(headerValue, templateContext);
+        if (hasTemplateVariables(value)) value = processTemplate(value, templateContext);
+        if (hasTemplateVariables(sublabel)) sublabel = processTemplate(sublabel, templateContext);
+      }
+
+      return {
+        label,
+        labelShort,
+        total: Number(headerValue) || 0,
+        modifier: value,
+        isProficient: false,
+        savingThrow: sublabel,
+      };
+    });
+
+    this.mount(AbilityCards, { abilities, showSavingPrefix: false });
+  }
+
+  private setupListeners() {
+    this.addUnloadFn(
+      this.ctx.onFrontmatterChange(() => {
+        if (!this.isTemplate) return;
+        this.processAndRender();
+      })
+    );
+
+    this.addUnloadFn(
+      this.ctx.onAbilitiesChange(() => {
+        if (!this.isTemplate) return;
+        this.processAndRender();
+      })
+    );
   }
 }

--- a/lib/views/RawAbilityView.ts
+++ b/lib/views/RawAbilityView.ts
@@ -1,7 +1,7 @@
 import { BaseView } from "./BaseView";
 import AbilityCards from "../components/AbilityCards.vue";
 import { MarkdownPostProcessorContext } from "obsidian";
-import { hasTemplateVariables, processTemplate } from "../utils/template";
+import { coerceNumericTemplate, processTemplate } from "../utils/template";
 import { TemplateAwareComponent } from "./TemplateAwareComponent";
 
 export class RawAbilityView extends BaseView {
@@ -18,35 +18,27 @@ class RawAbilityComponent extends TemplateAwareComponent {
     const parsed = this.parseSource();
     const items = Array.isArray(parsed?.items) ? parsed.items : [];
 
-    const templateContext = this.detectTemplates(
-      items.flatMap((item: any) => [
-        String(item.label || ""),
-        String(item.label_short || ""),
-        String(item.header_value || ""),
-        String(item.value || ""),
-        String(item.sublabel || ""),
-      ])
-    );
+    const sources = items.map((item: any) => ({
+      label: String(item.label ?? ""),
+      labelShort: String(item.label_short ?? ""),
+      headerValue: String(item.header_value ?? ""),
+      value: String(item.value ?? ""),
+      sublabel: String(item.sublabel ?? ""),
+    }));
 
-    const abilities = items.map((item: any) => {
-      let label = String(item.label || "");
-      let labelShort = String(item.label_short || "");
-      let headerValue = String(item.header_value || "0");
-      let value = String(item.value || "");
-      let sublabel = String(item.sublabel || "");
+    const templateContext = this.setupTemplates(sources.flatMap((s: { [k: string]: string }) => Object.values(s)));
 
-      if (templateContext) {
-        if (hasTemplateVariables(label)) label = processTemplate(label, templateContext);
-        if (hasTemplateVariables(labelShort)) labelShort = processTemplate(labelShort, templateContext);
-        if (hasTemplateVariables(headerValue)) headerValue = processTemplate(headerValue, templateContext);
-        if (hasTemplateVariables(value)) value = processTemplate(value, templateContext);
-        if (hasTemplateVariables(sublabel)) sublabel = processTemplate(sublabel, templateContext);
-      }
+    const abilities = sources.map((s: { [k: string]: string }) => {
+      const label = templateContext ? processTemplate(s.label, templateContext) : s.label;
+      const labelShort = templateContext ? processTemplate(s.labelShort, templateContext) : s.labelShort;
+      const headerValue = templateContext ? processTemplate(s.headerValue, templateContext) : s.headerValue;
+      const value = templateContext ? processTemplate(s.value, templateContext) : s.value;
+      const sublabel = templateContext ? processTemplate(s.sublabel, templateContext) : s.sublabel;
 
       return {
         label,
         labelShort,
-        total: Number(headerValue) || 0,
+        total: coerceNumericTemplate(headerValue, s.headerValue),
         modifier: value,
         isProficient: false,
         savingThrow: sublabel,

--- a/lib/views/RawSkillsView.ts
+++ b/lib/views/RawSkillsView.ts
@@ -1,11 +1,9 @@
 import { BaseView } from "./BaseView";
-import { VueMarkdown } from "./VueMarkdown";
 import SkillCards from "../components/SkillCards.vue";
-import { App, MarkdownPostProcessorContext } from "obsidian";
-import { parse } from "yaml";
+import { MarkdownPostProcessorContext } from "obsidian";
 import type { SkillItem } from "lib/types";
-import { hasTemplateVariables, processTemplate, createTemplateContext, TemplateContext } from "../utils/template";
-import { FileContext, useFileContext } from "./filecontext";
+import { hasTemplateVariables, processTemplate } from "../utils/template";
+import { TemplateAwareComponent } from "./TemplateAwareComponent";
 
 export class RawSkillsView extends BaseView {
   public codeblock = "skill-cards";
@@ -16,38 +14,18 @@ export class RawSkillsView extends BaseView {
   }
 }
 
-class RawSkillsComponent extends VueMarkdown {
-  ctx: FileContext;
-  source: string;
-  isTemplate = false;
-
-  constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
-    super(el);
-    this.source = source;
-    this.ctx = useFileContext(app, ctx);
-  }
-
-  async onload() {
-    this.setupListeners();
-    this.processAndRender();
-  }
-
-  private processAndRender() {
-    const parsed = parse(this.source);
+class RawSkillsComponent extends TemplateAwareComponent {
+  protected processAndRender() {
+    const parsed = this.parseSource();
     const rawItems = Array.isArray(parsed?.items) ? parsed.items : [];
 
-    const hasTemplates = rawItems.some(
-      (item: any) =>
-        hasTemplateVariables(String(item.label || "")) ||
-        hasTemplateVariables(String(item.ability || "")) ||
-        hasTemplateVariables(String(item.modifier ?? ""))
+    const templateContext = this.detectTemplates(
+      rawItems.flatMap((item: any) => [
+        String(item.label || ""),
+        String(item.ability || ""),
+        String(item.modifier ?? ""),
+      ])
     );
-
-    let templateContext: TemplateContext | null = null;
-    if (hasTemplates) {
-      templateContext = createTemplateContext(this.containerEl, this.ctx);
-      this.isTemplate = true;
-    }
 
     const items: SkillItem[] = rawItems.map((item: any) => {
       let label = String(item.label || "");
@@ -71,21 +49,5 @@ class RawSkillsComponent extends VueMarkdown {
     });
 
     this.mount(SkillCards, { items });
-  }
-
-  private setupListeners() {
-    this.addUnloadFn(
-      this.ctx.onFrontmatterChange(() => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
-
-    this.addUnloadFn(
-      this.ctx.onAbilitiesChange(() => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
   }
 }

--- a/lib/views/RawSkillsView.ts
+++ b/lib/views/RawSkillsView.ts
@@ -1,26 +1,91 @@
 import { BaseView } from "./BaseView";
 import { VueMarkdown } from "./VueMarkdown";
 import SkillCards from "../components/SkillCards.vue";
-import { MarkdownPostProcessorContext } from "obsidian";
+import { App, MarkdownPostProcessorContext } from "obsidian";
 import { parse } from "yaml";
 import type { SkillItem } from "lib/types";
+import { hasTemplateVariables, processTemplate, createTemplateContext, TemplateContext } from "../utils/template";
+import { FileContext, useFileContext } from "./filecontext";
 
 export class RawSkillsView extends BaseView {
   public codeblock = "skill-cards";
 
   public render(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext): void {
-    const parsed = parse(source);
-    const items: SkillItem[] = (parsed?.items || []).map((item: any) => ({
-      label: item.label || "",
-      ability: item.ability || "",
-      modifier: item.modifier ?? 0,
-      isProficient: item.proficiency === "proficient",
-      isExpert: item.proficiency === "expert",
-      isHalfProficient: item.proficiency === "half",
-    }));
+    const cmp = new RawSkillsComponent(el, source, this.app, ctx);
+    ctx.addChild(cmp);
+  }
+}
 
-    const child = new VueMarkdown(el);
-    child.mount(SkillCards, { items });
-    ctx.addChild(child);
+class RawSkillsComponent extends VueMarkdown {
+  ctx: FileContext;
+  source: string;
+  isTemplate = false;
+
+  constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
+    super(el);
+    this.source = source;
+    this.ctx = useFileContext(app, ctx);
+  }
+
+  async onload() {
+    this.setupListeners();
+    this.processAndRender();
+  }
+
+  private processAndRender() {
+    const parsed = parse(this.source);
+    const rawItems = Array.isArray(parsed?.items) ? parsed.items : [];
+
+    const hasTemplates = rawItems.some(
+      (item: any) =>
+        hasTemplateVariables(String(item.label || "")) ||
+        hasTemplateVariables(String(item.ability || "")) ||
+        hasTemplateVariables(String(item.modifier ?? ""))
+    );
+
+    let templateContext: TemplateContext | null = null;
+    if (hasTemplates) {
+      templateContext = createTemplateContext(this.containerEl, this.ctx);
+      this.isTemplate = true;
+    }
+
+    const items: SkillItem[] = rawItems.map((item: any) => {
+      let label = String(item.label || "");
+      let ability = String(item.ability || "");
+      let modifierStr = String(item.modifier ?? "0");
+
+      if (templateContext) {
+        if (hasTemplateVariables(label)) label = processTemplate(label, templateContext);
+        if (hasTemplateVariables(ability)) ability = processTemplate(ability, templateContext);
+        if (hasTemplateVariables(modifierStr)) modifierStr = processTemplate(modifierStr, templateContext);
+      }
+
+      return {
+        label,
+        ability,
+        modifier: Number(modifierStr) || 0,
+        isProficient: item.proficiency === "proficient",
+        isExpert: item.proficiency === "expert",
+        isHalfProficient: item.proficiency === "half",
+      };
+    });
+
+    this.mount(SkillCards, { items });
+  }
+
+  private setupListeners() {
+    this.addUnloadFn(
+      this.ctx.onFrontmatterChange(() => {
+        if (!this.isTemplate) return;
+        this.processAndRender();
+      })
+    );
+
+    this.addUnloadFn(
+      this.ctx.onAbilitiesChange(() => {
+        if (!this.isTemplate) return;
+        this.processAndRender();
+      })
+    );
   }
 }

--- a/lib/views/RawSkillsView.ts
+++ b/lib/views/RawSkillsView.ts
@@ -2,7 +2,7 @@ import { BaseView } from "./BaseView";
 import SkillCards from "../components/SkillCards.vue";
 import { MarkdownPostProcessorContext } from "obsidian";
 import type { SkillItem } from "lib/types";
-import { hasTemplateVariables, processTemplate } from "../utils/template";
+import { coerceNumericTemplate, processTemplate } from "../utils/template";
 import { TemplateAwareComponent } from "./TemplateAwareComponent";
 
 export class RawSkillsView extends BaseView {
@@ -19,34 +19,33 @@ class RawSkillsComponent extends TemplateAwareComponent {
     const parsed = this.parseSource();
     const rawItems = Array.isArray(parsed?.items) ? parsed.items : [];
 
-    const templateContext = this.detectTemplates(
-      rawItems.flatMap((item: any) => [
-        String(item.label || ""),
-        String(item.ability || ""),
-        String(item.modifier ?? ""),
-      ])
+    const sources = rawItems.map((item: any) => ({
+      label: String(item.label ?? ""),
+      ability: String(item.ability ?? ""),
+      modifier: String(item.modifier ?? ""),
+      proficiency: item.proficiency,
+    }));
+
+    const templateContext = this.setupTemplates(
+      sources.flatMap((s: { label: string; ability: string; modifier: string }) => [s.label, s.ability, s.modifier])
     );
 
-    const items: SkillItem[] = rawItems.map((item: any) => {
-      let label = String(item.label || "");
-      let ability = String(item.ability || "");
-      let modifierStr = String(item.modifier ?? "0");
+    const items: SkillItem[] = sources.map(
+      (s: { label: string; ability: string; modifier: string; proficiency: string }) => {
+        const label = templateContext ? processTemplate(s.label, templateContext) : s.label;
+        const ability = templateContext ? processTemplate(s.ability, templateContext) : s.ability;
+        const modifierStr = templateContext ? processTemplate(s.modifier, templateContext) : s.modifier;
 
-      if (templateContext) {
-        if (hasTemplateVariables(label)) label = processTemplate(label, templateContext);
-        if (hasTemplateVariables(ability)) ability = processTemplate(ability, templateContext);
-        if (hasTemplateVariables(modifierStr)) modifierStr = processTemplate(modifierStr, templateContext);
+        return {
+          label,
+          ability,
+          modifier: coerceNumericTemplate(modifierStr, s.modifier),
+          isProficient: s.proficiency === "proficient",
+          isExpert: s.proficiency === "expert",
+          isHalfProficient: s.proficiency === "half",
+        };
       }
-
-      return {
-        label,
-        ability,
-        modifier: Number(modifierStr) || 0,
-        isProficient: item.proficiency === "proficient",
-        isExpert: item.proficiency === "expert",
-        isHalfProficient: item.proficiency === "half",
-      };
-    });
+    );
 
     this.mount(SkillCards, { items });
   }

--- a/lib/views/TemplateAwareComponent.ts
+++ b/lib/views/TemplateAwareComponent.ts
@@ -1,0 +1,64 @@
+import { App, MarkdownPostProcessorContext } from "obsidian";
+import { parse } from "yaml";
+import { VueMarkdown } from "./VueMarkdown";
+import { FileContext, useFileContext } from "./filecontext";
+import { hasTemplateVariables, createTemplateContext, TemplateContext } from "../utils/template";
+
+/**
+ * Base class for view components that support Handlebars-style template variables
+ * in their YAML source. Handles YAML parsing, template detection, context creation,
+ * and re-rendering on frontmatter/ability changes.
+ *
+ * Subclasses implement `processAndRender()` to define their specific YAML-to-props
+ * mapping and Vue component mounting.
+ */
+export abstract class TemplateAwareComponent extends VueMarkdown {
+  protected fileContext: FileContext;
+  protected source: string;
+  protected isTemplate = false;
+
+  constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
+    super(el);
+    this.source = source;
+    this.fileContext = useFileContext(app, ctx);
+  }
+
+  async onload() {
+    this.setupListeners();
+    this.processAndRender();
+  }
+
+  protected abstract processAndRender(): void;
+
+  protected parseSource(): Record<string, any> {
+    return parse(this.source) || {};
+  }
+
+  /**
+   * Checks an array of string values for template variables. If any are found,
+   * creates and returns a TemplateContext and marks this component as template-aware.
+   */
+  protected detectTemplates(values: string[]): TemplateContext | null {
+    const hasTemplates = values.some((v) => hasTemplateVariables(v));
+    if (!hasTemplates) return null;
+
+    this.isTemplate = true;
+    return createTemplateContext(this.containerEl, this.fileContext);
+  }
+
+  private setupListeners() {
+    this.addUnloadFn(
+      this.fileContext.onFrontmatterChange(() => {
+        if (!this.isTemplate) return;
+        this.processAndRender();
+      })
+    );
+
+    this.addUnloadFn(
+      this.fileContext.onAbilitiesChange(() => {
+        if (!this.isTemplate) return;
+        this.processAndRender();
+      })
+    );
+  }
+}

--- a/lib/views/TemplateAwareComponent.ts
+++ b/lib/views/TemplateAwareComponent.ts
@@ -24,8 +24,8 @@ export abstract class TemplateAwareComponent extends VueMarkdown {
   }
 
   async onload() {
-    this.setupListeners();
     this.processAndRender();
+    this.setupListeners();
   }
 
   protected abstract processAndRender(): void;
@@ -35,11 +35,13 @@ export abstract class TemplateAwareComponent extends VueMarkdown {
   }
 
   /**
-   * Checks an array of string values for template variables. If any are found,
-   * creates and returns a TemplateContext and marks this component as template-aware.
+   * Inspects an array of source strings for template variables. If any are found,
+   * marks this component as template-aware (so frontmatter/ability change events
+   * trigger re-renders) and returns a TemplateContext for use by the subclass.
+   * Returns null when no templates are present, signaling a static-only render.
    */
-  protected detectTemplates(values: string[]): TemplateContext | null {
-    const hasTemplates = values.some((v) => hasTemplateVariables(v));
+  protected setupTemplates(sources: string[]): TemplateContext | null {
+    const hasTemplates = sources.some((v) => hasTemplateVariables(v));
     if (!hasTemplates) return null;
 
     this.isTemplate = true;


### PR DESCRIPTION
## Summary
- Add `{{ }}` template support to `ability-cards` and `skill-cards` components, enabling frontmatter-driven values and calculations (same as badges/stats)
- All text/numeric properties on both components now process Handlebars templates with access to `frontmatter.*`, `abilities.*`, `skills.*`, and all helper functions (`add`, `modifier`, `floor`, etc.)
- Components reactively re-render when frontmatter or ability data changes
- Updated docs with `†` template markers on supported properties and dynamic content examples

## Test plan
- [ ] Verify `ability-cards` renders static values unchanged (no regression)
- [ ] Verify `skill-cards` renders static values unchanged (no regression)
- [ ] Test `ability-cards` with `{{ frontmatter.x }}` in `header_value`, `value`, and `sublabel` fields
- [ ] Test `skill-cards` with `{{ frontmatter.x }}` in `modifier` field
- [ ] Verify cards re-render when frontmatter values are edited
- [ ] Test template helper functions (e.g. `{{ add 10 frontmatter.bonus }}`) in both components
- [ ] Confirm all existing tests pass (`npm run test`)