### PR TITLE
fix: resolve dynamic content templates in ability block (#63)

### DIFF
--- a/lib/domains/abilities.test.ts
+++ b/lib/domains/abilities.test.ts
@@ -2,13 +2,15 @@ import { describe, it, expect, vi } from "vitest";
 import {
   parseAbilityBlock,
   parseAbilityBlockFromDocument,
+  resolveAbilityBlock,
   calculateModifier,
   formatModifier,
   getModifiersForAbility,
   getTotalScore,
   getSavingThrowBonus,
+  RawAbilityBlock,
 } from "./abilities";
-import { GenericBonus } from "../types";
+import { Frontmatter, GenericBonus } from "../types";
 
 describe("abilities", () => {
   describe("parseAbilityBlock", () => {
@@ -299,6 +301,113 @@ abilities:
       } as any;
 
       expect(() => parseAbilityBlockFromDocument(mockElement, mockContext)).toThrow("No ability code blocks found");
+    });
+  });
+
+  describe("resolveAbilityBlock", () => {
+    function rawBlock(abilities: Partial<RawAbilityBlock["abilities"]>): RawAbilityBlock {
+      return {
+        abilities: {
+          strength: 0,
+          dexterity: 0,
+          constitution: 0,
+          intelligence: 0,
+          wisdom: 0,
+          charisma: 0,
+          ...abilities,
+        },
+        bonuses: [],
+        proficiencies: [],
+      };
+    }
+
+    it("passes numeric values through unchanged", () => {
+      const raw = rawBlock({
+        strength: 14,
+        dexterity: 12,
+        constitution: 13,
+        intelligence: 10,
+        wisdom: 16,
+        charisma: 8,
+      });
+
+      const result = resolveAbilityBlock(raw, null);
+
+      expect(result.abilities).toEqual({
+        strength: 14,
+        dexterity: 12,
+        constitution: 13,
+        intelligence: 10,
+        wisdom: 16,
+        charisma: 8,
+      });
+    });
+
+    it("resolves frontmatter templates to numbers", () => {
+      const raw = rawBlock({ strength: "{{frontmatter.str}}" });
+      const fm: Frontmatter = { proficiency_bonus: 2, str: 16 };
+
+      const result = resolveAbilityBlock(raw, fm);
+
+      expect(result.abilities.strength).toBe(16);
+    });
+
+    it("falls back to 0 and warns when a template references a missing frontmatter key", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const raw = rawBlock({ strength: "{{frontmatter.str}}" });
+      const fm: Frontmatter = { proficiency_bonus: 2 };
+
+      const result = resolveAbilityBlock(raw, fm);
+
+      expect(result.abilities.strength).toBe(0);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("strength");
+
+      warnSpy.mockRestore();
+    });
+
+    it("handles a mix of templated and non-templated abilities", () => {
+      const raw = rawBlock({
+        strength: "{{frontmatter.str}}",
+        dexterity: 12,
+        constitution: "{{frontmatter.con}}",
+        intelligence: 10,
+        wisdom: 14,
+        charisma: 8,
+      });
+      const fm: Frontmatter = { proficiency_bonus: 2, str: 18, con: 15 };
+
+      const result = resolveAbilityBlock(raw, fm);
+
+      expect(result.abilities).toEqual({
+        strength: 18,
+        dexterity: 12,
+        constitution: 15,
+        intelligence: 10,
+        wisdom: 14,
+        charisma: 8,
+      });
+    });
+
+    it("preserves bonuses and proficiencies on the resolved block", () => {
+      const raw: RawAbilityBlock = {
+        abilities: {
+          strength: 14,
+          dexterity: 0,
+          constitution: 0,
+          intelligence: 0,
+          wisdom: 0,
+          charisma: 0,
+        },
+        bonuses: [{ name: "Racial", target: "strength", value: 2 }],
+        proficiencies: ["strength"],
+      };
+
+      const result = resolveAbilityBlock(raw, null);
+
+      expect(result.bonuses).toEqual([{ name: "Racial", target: "strength", value: 2 }]);
+      expect(result.proficiencies).toEqual(["strength"]);
     });
   });
 

--- a/lib/domains/abilities.ts
+++ b/lib/domains/abilities.ts
@@ -1,12 +1,52 @@
-import { AbilityBlock, GenericBonus, AbilityScores } from "lib/types";
+import { AbilityBlock, AbilityScores, Frontmatter, GenericBonus } from "lib/types";
 import { MarkdownPostProcessorContext } from "obsidian";
 import * as Utils from "lib/utils/utils";
 import { parse } from "yaml";
 import { extractFirstCodeBlock } from "../utils/codeblock-extractor";
+import { processTemplate } from "../utils/template";
 
 export { calculateModifier, formatModifier } from "./dnd/modifiers";
 
-export function parseAbilityBlockFromDocument(el: HTMLElement, ctx: MarkdownPostProcessorContext): AbilityBlock {
+export type RawAbilityScores = {
+  strength: number | string;
+  dexterity: number | string;
+  constitution: number | string;
+  intelligence: number | string;
+  wisdom: number | string;
+  charisma: number | string;
+};
+
+export type RawAbilityBlock = {
+  abilities: RawAbilityScores;
+  bonuses: GenericBonus[];
+  proficiencies: string[];
+};
+
+const ABILITY_KEYS: (keyof RawAbilityScores)[] = [
+  "strength",
+  "dexterity",
+  "constitution",
+  "intelligence",
+  "wisdom",
+  "charisma",
+];
+
+const EMPTY_FRONTMATTER: Frontmatter = { proficiency_bonus: 0 };
+
+const ZERO_ABILITIES: AbilityScores = {
+  strength: 0,
+  dexterity: 0,
+  constitution: 0,
+  intelligence: 0,
+  wisdom: 0,
+  charisma: 0,
+};
+
+export function parseAbilityBlockFromDocument(
+  el: HTMLElement,
+  ctx: MarkdownPostProcessorContext,
+  frontmatter?: Frontmatter | null
+): AbilityBlock {
   const sectionInfo = ctx.getSectionInfo(el);
   const documentText = sectionInfo?.text || "";
 
@@ -16,11 +56,12 @@ export function parseAbilityBlockFromDocument(el: HTMLElement, ctx: MarkdownPost
     throw new Error("No ability code blocks found");
   }
 
-  return parseAbilityBlock(abilityContent);
+  const raw = parseAbilityBlock(abilityContent);
+  return resolveAbilityBlock(raw, frontmatter ?? null);
 }
 
-export function parseAbilityBlock(yamlString: string): AbilityBlock {
-  const def: AbilityBlock = {
+export function parseAbilityBlock(yamlString: string): RawAbilityBlock {
+  const def: RawAbilityBlock = {
     abilities: {
       strength: 0,
       dexterity: 0,
@@ -35,6 +76,56 @@ export function parseAbilityBlock(yamlString: string): AbilityBlock {
 
   const parsed = parse(yamlString);
   return Utils.mergeWithDefaults(parsed, def);
+}
+
+/**
+ * Resolves a RawAbilityBlock (whose ability scores may be Handlebars template
+ * strings such as `{{frontmatter.str}}`) into an AbilityBlock with numeric
+ * scores. Templates are evaluated against a minimal context (frontmatter +
+ * zeroed abilities/skills) to avoid recursing through `createTemplateContext`,
+ * which itself calls `parseAbilityBlockFromDocument`. Non-finite results emit a
+ * console.warn and fall back to 0.
+ */
+export function resolveAbilityBlock(raw: RawAbilityBlock, frontmatter: Frontmatter | null): AbilityBlock {
+  const fm = frontmatter ?? EMPTY_FRONTMATTER;
+  const templateContext = {
+    frontmatter: fm,
+    abilities: { ...ZERO_ABILITIES },
+    skills: {
+      proficiencies: [],
+      expertise: [],
+      half_proficiencies: [],
+      bonuses: [],
+    },
+  };
+
+  const resolved: AbilityScores = { ...ZERO_ABILITIES };
+
+  for (const key of ABILITY_KEYS) {
+    const value = raw.abilities[key];
+    if (typeof value === "number") {
+      resolved[key] = value;
+      continue;
+    }
+
+    const processed = processTemplate(value, templateContext);
+    const trimmed = processed.trim();
+    const num = Number(trimmed);
+    if (trimmed !== "" && Number.isFinite(num)) {
+      resolved[key] = num;
+    } else {
+      console.warn(
+        `[dnd-ui-toolkit] Ability "${key}" template did not resolve to a number: ${JSON.stringify(processed)} (from ${JSON.stringify(value)})`
+      );
+      resolved[key] = 0;
+    }
+  }
+
+  return {
+    abilities: resolved,
+    bonuses: raw.bonuses,
+    proficiencies: raw.proficiencies,
+  };
 }
 
 export function getModifiersForAbility(modifiers: GenericBonus[], ability: keyof AbilityScores): GenericBonus[] {

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -94,7 +94,7 @@ export function createTemplateContext(el: HTMLElement, fileContext: FileContext)
 
   try {
     // Try to parse abilities from the document
-    const abilityBlock = parseAbilityBlockFromDocument(el, fileContext.md());
+    const abilityBlock = parseAbilityBlockFromDocument(el, fileContext.md(), frontmatter);
 
     // Calculate total scores including bonuses that modify the score
     abilities = {

--- a/lib/views/AbilityScoreView.test.ts
+++ b/lib/views/AbilityScoreView.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AbilityScoreView } from "./AbilityScoreView";
+import { App, MarkdownPostProcessorContext } from "obsidian";
+
+vi.mock("./VueMarkdown", () => {
+  return {
+    VueMarkdown: class {
+      public containerEl: HTMLElement;
+      public mount = vi.fn();
+      public mountReactive = vi.fn();
+      public addUnloadFn = vi.fn();
+      constructor(el: HTMLElement) {
+        this.containerEl = el;
+      }
+    },
+  };
+});
+
+const onFrontmatterChange = vi.fn((_cb: (...args: any[]) => void) => () => {});
+const onAbilitiesChange = vi.fn((_cb: (...args: any[]) => void) => () => {});
+const frontmatterFn = vi.fn(() => ({ proficiency_bonus: 2 }));
+
+vi.mock("./filecontext", () => ({
+  useFileContext: vi.fn((_app: App, ctx: MarkdownPostProcessorContext) => ({
+    filepath: ctx.sourcePath,
+    frontmatter: frontmatterFn,
+    onFrontmatterChange,
+    onAbilitiesChange,
+    md: () => ctx,
+  })),
+}));
+
+describe("AbilityScoreView", () => {
+  let abilityView: AbilityScoreView;
+  let mockApp: App;
+  let mockElement: HTMLElement;
+  let mockContext: MarkdownPostProcessorContext;
+  let addedChild: any = null;
+
+  beforeEach(() => {
+    addedChild = null;
+    onFrontmatterChange.mockClear();
+    onAbilitiesChange.mockClear();
+    frontmatterFn.mockClear();
+    mockApp = {} as App;
+    abilityView = new AbilityScoreView(mockApp);
+    mockElement = {} as HTMLElement;
+    mockContext = {
+      sourcePath: "test.md",
+      addChild: vi.fn((child: any) => {
+        addedChild = child;
+      }),
+      getSectionInfo: vi.fn(() => null),
+    } as any;
+  });
+
+  it("does not subscribe to abilities:changed (publisher must not listen to itself)", async () => {
+    const source = `abilities:
+  strength: "{{frontmatter.str}}"`;
+    abilityView.render(source, mockElement, mockContext);
+    await addedChild.onload();
+
+    // Component subscribes to frontmatter changes (templated) but not to its own abilities:changed.
+    // Without this guard, msgbus.publish inside processAndRender would trigger a self-listener and recurse.
+    expect(onFrontmatterChange).toHaveBeenCalledTimes(1);
+    expect(onAbilitiesChange).not.toHaveBeenCalled();
+  });
+
+  it("re-renders once on a single frontmatter change without recursion", async () => {
+    const source = `abilities:
+  strength: "{{frontmatter.str}}"`;
+
+    let registeredCallback: (() => void) | null = null;
+    onFrontmatterChange.mockImplementation((cb: any) => {
+      registeredCallback = cb;
+      return () => {};
+    });
+
+    abilityView.render(source, mockElement, mockContext);
+    await addedChild.onload();
+
+    const initialMountCalls = addedChild.mount.mock.calls.length;
+    expect(initialMountCalls).toBeGreaterThanOrEqual(1);
+
+    expect(registeredCallback).not.toBeNull();
+    (registeredCallback as any)();
+
+    // Exactly one additional render — no recursion via abilities:changed.
+    expect(addedChild.mount.mock.calls.length).toBe(initialMountCalls + 1);
+  });
+
+  it("does not subscribe at all for non-templated ability blocks", async () => {
+    const source = `abilities:
+  strength: 14
+  dexterity: 12`;
+    abilityView.render(source, mockElement, mockContext);
+    await addedChild.onload();
+
+    // setupTemplates returns null for non-templated sources, so isTemplate stays false
+    // and the frontmatter listener short-circuits — but the listener IS still registered.
+    // The abilities listener is never registered for this component regardless.
+    expect(onAbilitiesChange).not.toHaveBeenCalled();
+  });
+});

--- a/lib/views/AbilityScoreView.ts
+++ b/lib/views/AbilityScoreView.ts
@@ -1,18 +1,25 @@
 import { BaseView } from "./BaseView";
-import { VueMarkdown } from "./VueMarkdown";
+import { TemplateAwareComponent } from "./TemplateAwareComponent";
 import AbilityCards from "../components/AbilityCards.vue";
 import { MarkdownPostProcessorContext } from "obsidian";
 import * as AbilityService from "lib/domains/abilities";
-import { useFileContext } from "./filecontext";
 import { msgbus } from "lib/services/event-bus";
 
 export class AbilityScoreView extends BaseView {
   public codeblock = "ability";
 
   public render(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext): void {
-    const abilityBlock = AbilityService.parseAbilityBlock(source);
-    const fc = useFileContext(this.app, ctx);
-    const frontmatter = fc.frontmatter();
+    const cmp = new AbilityScoreComponent(el, source, this.app, ctx);
+    ctx.addChild(cmp);
+  }
+}
+
+class AbilityScoreComponent extends TemplateAwareComponent {
+  protected processAndRender() {
+    const raw = AbilityService.parseAbilityBlock(this.source);
+    this.setupTemplates([this.source]);
+    const frontmatter = this.fileContext.frontmatter();
+    const abilityBlock = AbilityService.resolveAbilityBlock(raw, frontmatter);
 
     const abilities = (Object.entries(abilityBlock.abilities) as [string, number][]).map(([key, value]) => {
       const isProficient = abilityBlock.proficiencies.includes(key);
@@ -41,10 +48,8 @@ export class AbilityScoreView extends BaseView {
       };
     });
 
-    msgbus.publish(ctx.sourcePath, "abilities:changed", undefined);
+    msgbus.publish(this.fileContext.filepath, "abilities:changed", undefined);
 
-    const child = new VueMarkdown(el);
-    child.mount(AbilityCards, { abilities });
-    ctx.addChild(child);
+    this.mount(AbilityCards, { abilities });
   }
 }

--- a/lib/views/AbilityScoreView.ts
+++ b/lib/views/AbilityScoreView.ts
@@ -15,6 +15,8 @@ export class AbilityScoreView extends BaseView {
 }
 
 class AbilityScoreComponent extends TemplateAwareComponent {
+  protected listenToAbilitiesChange = false;
+
   protected processAndRender() {
     const raw = AbilityService.parseAbilityBlock(this.source);
     this.setupTemplates([this.source]);

--- a/lib/views/SkillsView.test.ts
+++ b/lib/views/SkillsView.test.ts
@@ -240,4 +240,37 @@ describe("SkillsView", () => {
 
     parseAbilityBlockSpy.mockRestore();
   });
+
+  it("renders skills when an ability score resolves to 0 (template fallback)", async () => {
+    const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
+    // Simulates resolveAbilityBlock falling back to 0 for an unresolvable template:
+    // a strict !skillAbility check would treat 0 as missing and throw.
+    parseAbilityBlockSpy.mockReturnValue({
+      abilities: {
+        strength: 0,
+        dexterity: 14,
+        constitution: 12,
+        intelligence: 10,
+        wisdom: 8,
+        charisma: 16,
+      },
+      bonuses: [],
+      proficiencies: [],
+    });
+
+    const skillsYaml = `proficiencies:
+  - athletics`;
+
+    skillsView.render(skillsYaml, mockElement, mockContext);
+    await addedChild.onload();
+
+    expect(addedChild.mount).toHaveBeenCalled();
+    const props = addedChild.mount.mock.calls[0][1];
+    const athletics = props.items.find((i: any) => i.label.toLowerCase() === "athletics");
+    expect(athletics).toBeDefined();
+    // Strength 0 → modifier -5; +3 proficiency → -2.
+    expect(athletics.modifier).toBe(-2);
+
+    parseAbilityBlockSpy.mockRestore();
+  });
 });

--- a/lib/views/SkillsView.test.ts
+++ b/lib/views/SkillsView.test.ts
@@ -3,19 +3,37 @@ import { SkillsView } from "./SkillsView";
 import { App, MarkdownPostProcessorContext } from "obsidian";
 import * as AbilityService from "../domains/abilities";
 
-// Mock VueMarkdown to avoid DOM issues in Node environment
-vi.mock("./VueMarkdown", () => ({
-  VueMarkdown: vi.fn().mockImplementation(() => ({
-    mount: vi.fn(),
-  })),
-}));
+// Mock VueMarkdown to avoid DOM issues in Node environment.
+// TemplateAwareComponent extends VueMarkdown, so we capture mount calls and
+// preserve a working containerEl/addUnloadFn surface.
+vi.mock("./VueMarkdown", () => {
+  return {
+    VueMarkdown: class {
+      public containerEl: HTMLElement;
+      public mount = vi.fn();
+      public mountReactive = vi.fn();
+      public addUnloadFn = vi.fn();
+      constructor(el: HTMLElement) {
+        this.containerEl = el;
+      }
+    },
+  };
+});
 
-// Mock the file context
+// onFrontmatterChange/onAbilitiesChange need to return unsubscribe fns;
+// frontmatter() is called during processAndRender.
+const onFrontmatterChange = vi.fn((_cb: (...args: any[]) => void) => () => {});
+const onAbilitiesChange = vi.fn((_cb: (...args: any[]) => void) => () => {});
+
 vi.mock("./filecontext", () => ({
-  useFileContext: vi.fn(() => ({
+  useFileContext: vi.fn((_app: App, ctx: MarkdownPostProcessorContext) => ({
+    filepath: ctx.sourcePath,
     frontmatter: vi.fn(() => ({
       proficiency_bonus: 3,
     })),
+    onFrontmatterChange,
+    onAbilitiesChange,
+    md: () => ctx,
   })),
 }));
 
@@ -24,19 +42,27 @@ describe("SkillsView", () => {
   let mockApp: App;
   let mockElement: HTMLElement;
   let mockContext: MarkdownPostProcessorContext;
+  let addedChild: any = null;
 
   beforeEach(() => {
+    addedChild = null;
+    onFrontmatterChange.mockClear();
+    onAbilitiesChange.mockClear();
     mockApp = {} as App;
     skillsView = new SkillsView(mockApp);
     mockElement = {
       createEl: vi.fn(() => ({ createEl: vi.fn() })),
     } as any;
     mockContext = {
-      addChild: vi.fn(),
+      sourcePath: "test.md",
+      addChild: vi.fn((child: any) => {
+        addedChild = child;
+      }),
+      getSectionInfo: vi.fn(() => null),
     } as any;
   });
 
-  it("should handle missing ability block gracefully", () => {
+  it("should handle missing ability block gracefully", async () => {
     const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
     parseAbilityBlockSpy.mockImplementation(() => {
       throw new Error("No ability code blocks found");
@@ -49,13 +75,14 @@ describe("SkillsView", () => {
   - intimidation`;
 
     expect(() => skillsView.render(skillsYaml, mockElement, mockContext)).not.toThrow();
+    await addedChild.onload();
     expect(consoleDebugSpy).toHaveBeenCalledWith("No ability block found for skills view, using default values");
 
     parseAbilityBlockSpy.mockRestore();
     consoleDebugSpy.mockRestore();
   });
 
-  it("should use ability scores when ability block is found", () => {
+  it("should use ability scores when ability block is found", async () => {
     const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
     parseAbilityBlockSpy.mockReturnValue({
       abilities: {
@@ -74,11 +101,13 @@ describe("SkillsView", () => {
   - athletics`;
 
     expect(() => skillsView.render(skillsYaml, mockElement, mockContext)).not.toThrow();
+    await addedChild.onload();
+    expect(parseAbilityBlockSpy).toHaveBeenCalled();
 
     parseAbilityBlockSpy.mockRestore();
   });
 
-  it("should use default ability scores (10) when no ability block found", () => {
+  it("should use default ability scores (10) when no ability block found", async () => {
     const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
     parseAbilityBlockSpy.mockImplementation(() => {
       throw new Error("No ability code blocks found");
@@ -88,6 +117,126 @@ describe("SkillsView", () => {
   - athletics`;
 
     expect(() => skillsView.render(skillsYaml, mockElement, mockContext)).not.toThrow();
+    await addedChild.onload();
+
+    parseAbilityBlockSpy.mockRestore();
+  });
+
+  it("should subscribe to frontmatter and abilities changes when ability block uses templates", async () => {
+    const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
+    parseAbilityBlockSpy.mockReturnValue({
+      abilities: {
+        strength: 14,
+        dexterity: 12,
+        constitution: 13,
+        intelligence: 10,
+        wisdom: 8,
+        charisma: 16,
+      },
+      bonuses: [],
+      proficiencies: [],
+    });
+
+    // Section info containing an ability block with template variables.
+    (mockContext.getSectionInfo as any).mockReturnValue({
+      text: '```ability\nabilities:\n  strength: "{{frontmatter.str}}"\n```',
+      lineStart: 0,
+      lineEnd: 4,
+    });
+
+    const skillsYaml = `proficiencies:
+  - athletics`;
+
+    skillsView.render(skillsYaml, mockElement, mockContext);
+    await addedChild.onload();
+
+    // The component is template-aware, so listeners should be installed.
+    expect(onFrontmatterChange).toHaveBeenCalledTimes(1);
+    expect(onAbilitiesChange).toHaveBeenCalledTimes(1);
+
+    parseAbilityBlockSpy.mockRestore();
+  });
+
+  it("should re-render when subscribed frontmatter change fires", async () => {
+    const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
+    parseAbilityBlockSpy.mockReturnValue({
+      abilities: {
+        strength: 14,
+        dexterity: 12,
+        constitution: 13,
+        intelligence: 10,
+        wisdom: 8,
+        charisma: 16,
+      },
+      bonuses: [],
+      proficiencies: [],
+    });
+
+    (mockContext.getSectionInfo as any).mockReturnValue({
+      text: '```ability\nabilities:\n  strength: "{{frontmatter.str}}"\n```',
+      lineStart: 0,
+      lineEnd: 4,
+    });
+
+    let registeredCallback: (() => void) | null = null;
+    onFrontmatterChange.mockImplementation((cb: any) => {
+      registeredCallback = cb;
+      return () => {};
+    });
+
+    const skillsYaml = `proficiencies:
+  - athletics`;
+
+    skillsView.render(skillsYaml, mockElement, mockContext);
+    await addedChild.onload();
+
+    const callsAfterInitial = parseAbilityBlockSpy.mock.calls.length;
+    expect(callsAfterInitial).toBeGreaterThanOrEqual(1);
+
+    // Trigger the registered frontmatter-change callback — should re-render.
+    expect(registeredCallback).not.toBeNull();
+    (registeredCallback as any)();
+
+    expect(parseAbilityBlockSpy.mock.calls.length).toBeGreaterThan(callsAfterInitial);
+
+    parseAbilityBlockSpy.mockRestore();
+  });
+
+  it("produces numeric skill modifiers from a resolved ability block", async () => {
+    const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
+    // Simulate the resolved block (e.g. after templates have been applied).
+    parseAbilityBlockSpy.mockReturnValue({
+      abilities: {
+        strength: 18, // +4
+        dexterity: 14, // +2
+        constitution: 12,
+        intelligence: 10,
+        wisdom: 8,
+        charisma: 16,
+      },
+      bonuses: [],
+      proficiencies: [],
+    });
+
+    const skillsYaml = `proficiencies:
+  - athletics`;
+
+    skillsView.render(skillsYaml, mockElement, mockContext);
+    await addedChild.onload();
+
+    // mount should have been called with finite numeric modifiers.
+    expect(addedChild.mount).toHaveBeenCalled();
+    const mountArgs = addedChild.mount.mock.calls[0];
+    const props = mountArgs[1];
+    expect(Array.isArray(props.items)).toBe(true);
+    for (const item of props.items) {
+      expect(Number.isFinite(item.modifier)).toBe(true);
+    }
+
+    // Athletics is STR-based and listed as a proficiency: +4 (mod) + 3 (prof) = +7.
+    const athletics = props.items.find((i: any) => i.label.toLowerCase() === "athletics");
+    expect(athletics).toBeDefined();
+    expect(athletics.modifier).toBe(7);
 
     parseAbilityBlockSpy.mockRestore();
   });

--- a/lib/views/SkillsView.ts
+++ b/lib/views/SkillsView.ts
@@ -1,20 +1,35 @@
 import { BaseView } from "./BaseView";
-import { VueMarkdown } from "./VueMarkdown";
+import { TemplateAwareComponent } from "./TemplateAwareComponent";
 import SkillCards from "../components/SkillCards.vue";
 import { MarkdownPostProcessorContext } from "obsidian";
 import * as AbilityService from "lib/domains/abilities";
 import * as SkillsService from "lib/domains/skills";
 import { AbilityBlock, AbilityScores, SkillItem } from "lib/types";
-import { useFileContext } from "./filecontext";
+import { extractFirstCodeBlock } from "../utils/codeblock-extractor";
 
 export class SkillsView extends BaseView {
   public codeblock = "skills";
 
   public render(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext): void {
-    let abilityBlock: AbilityBlock;
+    const cmp = new SkillsComponent(el, source, this.app, ctx);
+    ctx.addChild(cmp);
+  }
+}
 
+class SkillsComponent extends TemplateAwareComponent {
+  protected processAndRender() {
+    const skillsBlock = SkillsService.parseSkillsBlock(this.source);
+
+    const sectionInfo = this.fileContext.md().getSectionInfo(this.containerEl);
+    const documentText = sectionInfo?.text || "";
+    const abilityBlockSrc = extractFirstCodeBlock(documentText, "ability") ?? "";
+
+    this.setupTemplates([this.source, abilityBlockSrc]);
+
+    const frontmatter = this.fileContext.frontmatter();
+    let abilityBlock: AbilityBlock;
     try {
-      abilityBlock = AbilityService.parseAbilityBlockFromDocument(el, ctx);
+      abilityBlock = AbilityService.parseAbilityBlockFromDocument(this.containerEl, this.fileContext.md(), frontmatter);
     } catch {
       console.debug("No ability block found for skills view, using default values");
       abilityBlock = {
@@ -31,9 +46,6 @@ export class SkillsView extends BaseView {
       };
     }
 
-    const skillsBlock = SkillsService.parseSkillsBlock(source);
-    const fc = useFileContext(this.app, ctx);
-    const frontmatter = fc.frontmatter();
     const items: SkillItem[] = [];
 
     for (const skill of SkillsService.Skills) {
@@ -76,8 +88,6 @@ export class SkillsView extends BaseView {
       });
     }
 
-    const child = new VueMarkdown(el);
-    child.mount(SkillCards, { items });
-    ctx.addChild(child);
+    this.mount(SkillCards, { items });
   }
 }

--- a/lib/views/SkillsView.ts
+++ b/lib/views/SkillsView.ts
@@ -56,7 +56,7 @@ class SkillsComponent extends TemplateAwareComponent {
       const isExpert = skillsBlock.expertise.some((x) => x.toLowerCase() === skill.label.toLowerCase());
 
       const skillAbility = abilityBlock.abilities[skill.ability as keyof AbilityBlock["abilities"]];
-      if (!skillAbility) {
+      if (skillAbility === undefined) {
         throw new Error(`Skill ${skill.ability} not found in Skills list`);
       }
 

--- a/lib/views/SpellComponentsView.ts
+++ b/lib/views/SpellComponentsView.ts
@@ -86,9 +86,10 @@ export class SpellComponentsView extends BaseView {
     try {
       let abilityBlock;
       if (abilityBlockContent) {
-        abilityBlock = AbilityService.parseAbilityBlock(abilityBlockContent);
+        const raw = AbilityService.parseAbilityBlock(abilityBlockContent);
+        abilityBlock = AbilityService.resolveAbilityBlock(raw, frontmatter);
       } else {
-        abilityBlock = AbilityService.parseAbilityBlockFromDocument(el, ctx);
+        abilityBlock = AbilityService.parseAbilityBlockFromDocument(el, ctx, frontmatter);
       }
 
       const baseScore = abilityBlock.abilities[abilityName as keyof AbilityScores];

--- a/lib/views/TemplateAwareComponent.ts
+++ b/lib/views/TemplateAwareComponent.ts
@@ -16,6 +16,11 @@ export abstract class TemplateAwareComponent extends VueMarkdown {
   protected fileContext: FileContext;
   protected source: string;
   protected isTemplate = false;
+  /**
+   * Set to false in components that themselves publish `abilities:changed`,
+   * so they don't subscribe to their own event and recurse on re-render.
+   */
+  protected listenToAbilitiesChange = true;
 
   constructor(el: HTMLElement, source: string, app: App, ctx: MarkdownPostProcessorContext) {
     super(el);
@@ -56,11 +61,13 @@ export abstract class TemplateAwareComponent extends VueMarkdown {
       })
     );
 
-    this.addUnloadFn(
-      this.fileContext.onAbilitiesChange(() => {
-        if (!this.isTemplate) return;
-        this.processAndRender();
-      })
-    );
+    if (this.listenToAbilitiesChange) {
+      this.addUnloadFn(
+        this.fileContext.onAbilitiesChange(() => {
+          if (!this.isTemplate) return;
+          this.processAndRender();
+        })
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes [#63](https://github.com/hay-kot/obsidian-dnd-ui-toolkit/issues/63): templated ability scores like `strength: "{{frontmatter.str}}"` in the `ability` codeblock were rendering as `NaN`. The cleanup commit `1a82f84` removed `processAbilityBlockTemplate` and the Vue rewrite never restored template resolution for this codeblock.
- Splits ability parsing into a raw shape (`RawAbilityBlock` with `string | number` scores) and a resolved shape (`AbilityBlock`). New `resolveAbilityBlock(raw, frontmatter)` runs Handlebars against a minimal context (zeroed abilities/skills) so a user template like `{{abilities.dexterity}}` returns `0` instead of recursing through `createTemplateContext`.
- Converts `AbilityScoreView` and `SkillsView` to `TemplateAwareComponent` so both re-render reactively when frontmatter changes. SkillsView also watches the ability block source, so it re-renders when a templated ability score changes. Side-effect: skills now react to `proficiency_bonus` changes in real time (previously stale).
- Threads `frontmatter` through `parseAbilityBlockFromDocument` and updates `template.ts` + `SpellComponentsView` to resolve raw blocks.

## Test plan

- [x] `task check` (format + lint + typecheck + vitest) — 383/383 pass
- [x] New unit tests in `lib/domains/abilities.test.ts` cover numeric pass-through, frontmatter template resolution, missing-key fallback with `console.warn`, mixed templated/non-templated abilities, and bonus/proficiency preservation
- [x] `lib/views/SkillsView.test.ts` reworked for the new component shape; adds: subscription installs when ability block uses templates, frontmatter-change re-renders, mounted props contain finite numeric modifiers (athletics with STR 18 + prof 3 = +7)
- [x] Manual: open a note with `str: 14` in frontmatter and an `ability` block using `strength: "{{frontmatter.str}}"`; confirm STR renders as 14 (not NaN), updates live when frontmatter changes, and that a `skills` block in the same note picks up the resolved value
- [x] Manual: regression — existing notes with plain numeric ability scores still render unchanged