### PR TITLE
feat: track advantage/disadvantage on saves and skills (#67)

### DIFF
--- a/docs/character-sheet/ability-scores.md
+++ b/docs/character-sheet/ability-scores.md
@@ -30,11 +30,15 @@ proficiencies:
 
 ## Configuration
 
-| Property        | Type   | Default  | Description                                                                             |
-| --------------- | ------ | -------- | --------------------------------------------------------------------------------------- |
-| `abilities`     | Object | Required | Ability score values (strength, dexterity, constitution, intelligence, wisdom, charisma) |
-| `bonuses`       | Array  | —        | List of bonuses to apply to ability scores or saving throws                             |
-| `proficiencies` | Array  | —        | List of abilities you are proficient in for saving throws                               |
+| Property         | Type   | Default  | Description                                                                               |
+| ---------------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
+| `abilities`      | Object | Required | Ability score values (strength, dexterity, constitution, intelligence, wisdom, charisma) |
+| `bonuses`        | Array  | —        | List of bonuses to apply to ability scores or saving throws                              |
+| `proficiencies`  | Array  | —        | List of abilities you are proficient in for saving throws                                |
+| `advantage` †    | Object | —        | Map of abilities to booleans; a `true` value colors that saving throw green              |
+| `disadvantage` † | Object | —        | Map of abilities to booleans; a `true` value colors that saving throw red                |
+
+† Supports [dynamic content](/concepts/dynamic-content) templates
 
 ### Bonus Object
 
@@ -44,3 +48,29 @@ proficiencies:
 | `target`   | String | Required       | Which ability the bonus applies to                  |
 | `value`    | Number | Required       | The bonus value to add                              |
 | `modifies` | String | "saving_throw" | Either `"score"` or `"saving_throw"` |
+
+## Advantage & Disadvantage
+
+Highlight saving throws that currently have advantage or disadvantage. Keys accept the full ability name (`strength`) or its abbreviation (`str`). A `true` value colors the save green (advantage) or red (disadvantage); if a save is both, or neither, it is left uncolored.
+
+````yaml
+```ability
+abilities:
+  strength: 15
+  dexterity: 14
+  constitution: 13
+  intelligence: 12
+  wisdom: 10
+  charisma: 8
+
+advantage:
+  strength: true
+  # Bind the value to frontmatter so a Meta Bind toggle can flip it live
+  dexterity: "{{frontmatter.dexAdvantage}}"
+
+disadvantage:
+  wisdom: "{{frontmatter.wisDisadvantage}}"
+```
+````
+
+Because the templated values read from frontmatter, a [Meta Bind](https://cwyther.gitbook.io/obsidian-meta-bind-plugin) toggle bound to `dexAdvantage` (etc.) updates the coloring the moment it changes.

--- a/docs/character-sheet/skills.md
+++ b/docs/character-sheet/skills.md
@@ -34,12 +34,16 @@ The skills block automatically displays all 18 D&D 5e skills: Acrobatics, Animal
 
 ## Configuration
 
-| Property             | Type  | Default | Description                                               |
-| -------------------- | ----- | ------- | --------------------------------------------------------- |
-| `proficiencies`      | Array | —       | List of skills you are proficient in                      |
-| `expertise`          | Array | —       | List of skills you have expertise in (double proficiency) |
-| `half_proficiencies` | Array | —       | List of skills you have half proficiency in               |
-| `bonuses`            | Array | —       | List of bonuses to apply to specific skills               |
+| Property             | Type   | Default | Description                                                          |
+| -------------------- | ------ | ------- | ------------------------------------------------------------------- |
+| `proficiencies`      | Array  | —       | List of skills you are proficient in                                |
+| `expertise`          | Array  | —       | List of skills you have expertise in (double proficiency)           |
+| `half_proficiencies` | Array  | —       | List of skills you have half proficiency in                         |
+| `bonuses`            | Array  | —       | List of bonuses to apply to specific skills                         |
+| `advantage` †        | Object | —       | Map of skills to booleans; a `true` value colors that skill green   |
+| `disadvantage` †     | Object | —       | Map of skills to booleans; a `true` value colors that skill red     |
+
+† Supports [dynamic content](/concepts/dynamic-content) templates
 
 ### Bonus Object
 
@@ -48,3 +52,25 @@ The skills block automatically displays all 18 D&D 5e skills: Acrobatics, Animal
 | `name`   | String | Required | Name of the bonus (for display purposes) |
 | `target` | String | Required | Which skill the bonus applies to         |
 | `value`  | Number | Required | The bonus value to add                   |
+
+## Advantage & Disadvantage
+
+Highlight skills that currently have advantage or disadvantage. Keys are skill names (e.g. `perception`, `stealth`). A `true` value colors the skill name and value green (advantage) or red (disadvantage); a skill flagged as both, or neither, is left uncolored.
+
+````yaml
+```skills
+proficiencies:
+  - perception
+  - stealth
+
+advantage:
+  perception: true
+  # Bind the value to frontmatter so a Meta Bind toggle can flip it live
+  stealth: "{{frontmatter.stealthAdvantage}}"
+
+disadvantage:
+  athletics: "{{frontmatter.athleticsDisadvantage}}"
+```
+````
+
+Because the templated values read from frontmatter, a [Meta Bind](https://cwyther.gitbook.io/obsidian-meta-bind-plugin) toggle bound to `stealthAdvantage` (etc.) updates the coloring the moment it changes.

--- a/lib/components/AbilityCards.vue
+++ b/lib/components/AbilityCards.vue
@@ -6,6 +6,8 @@ interface AbilityCardItem {
   modifier: string;
   isProficient: boolean;
   savingThrow: string;
+  hasAdvantage?: boolean;
+  hasDisadvantage?: boolean;
 }
 
 withDefaults(
@@ -30,7 +32,10 @@ withDefaults(
           <p v-if="item.total" class="dnd-ui-ability-value">{{ item.total }}</p>
         </div>
         <p class="dnd-ui-ability-modifier">{{ item.modifier }}</p>
-        <div class="dnd-ui-ability-modifier-saving">
+        <div
+          class="dnd-ui-ability-modifier-saving"
+          :class="{ 'dnd-ui-advantage': item.hasAdvantage, 'dnd-ui-disadvantage': item.hasDisadvantage }"
+        >
           <em>{{ showSavingPrefix ? `Saving ${item.savingThrow}` : item.savingThrow }}</em>
         </div>
       </div>

--- a/lib/components/SkillCards.vue
+++ b/lib/components/SkillCards.vue
@@ -11,6 +11,8 @@ function getSkillCardClasses(item: SkillItem): string[] {
   if (item.isExpert) classes.push("dnd-ui-expert");
   else if (item.isProficient) classes.push("dnd-ui-proficient");
   else if (item.isHalfProficient) classes.push("dnd-ui-half-proficient");
+  if (item.hasAdvantage) classes.push("dnd-ui-advantage");
+  else if (item.hasDisadvantage) classes.push("dnd-ui-disadvantage");
   return classes;
 }
 </script>

--- a/lib/domains/abilities.test.ts
+++ b/lib/domains/abilities.test.ts
@@ -409,6 +409,45 @@ abilities:
       expect(result.bonuses).toEqual([{ name: "Racial", target: "strength", value: 2 }]);
       expect(result.proficiencies).toEqual(["strength"]);
     });
+
+    it("resolves literal advantage/disadvantage entries by full name and abbreviation", () => {
+      const raw: RawAbilityBlock = {
+        ...rawBlock({}),
+        advantage: { strength: true, dex: true },
+        disadvantage: { wisdom: true },
+      };
+
+      const result = resolveAbilityBlock(raw, null);
+
+      expect(result.advantage).toEqual({ strength: true, dexterity: true });
+      expect(result.disadvantage).toEqual({ wisdom: true });
+    });
+
+    it("resolves advantage from a frontmatter boolean template", () => {
+      const raw: RawAbilityBlock = {
+        ...rawBlock({}),
+        advantage: { strength: "{{frontmatter.strAdvantage}}" },
+        disadvantage: { dexterity: "{{frontmatter.dexDisadvantage}}" },
+      };
+      const fm: Frontmatter = { proficiency_bonus: 2, strAdvantage: true, dexDisadvantage: false };
+
+      const result = resolveAbilityBlock(raw, fm);
+
+      expect(result.advantage).toEqual({ strength: true });
+      // false-valued entries are omitted rather than stored as false.
+      expect(result.disadvantage).toEqual({});
+    });
+
+    it("omits falsy entries and ignores unknown ability keys", () => {
+      const raw: RawAbilityBlock = {
+        ...rawBlock({}),
+        advantage: { strength: false, bogus: true },
+      };
+
+      const result = resolveAbilityBlock(raw, null);
+
+      expect(result.advantage).toEqual({});
+    });
   });
 
   describe("calculateModifier", () => {

--- a/lib/domains/abilities.ts
+++ b/lib/domains/abilities.ts
@@ -3,7 +3,7 @@ import { MarkdownPostProcessorContext } from "obsidian";
 import * as Utils from "lib/utils/utils";
 import { parse } from "yaml";
 import { extractFirstCodeBlock } from "../utils/codeblock-extractor";
-import { processTemplate } from "../utils/template";
+import { coerceBooleanTemplate, processTemplate, TemplateContext } from "../utils/template";
 
 export { calculateModifier, formatModifier } from "./dnd/modifiers";
 
@@ -20,6 +20,25 @@ export type RawAbilityBlock = {
   abilities: RawAbilityScores;
   bonuses: GenericBonus[];
   proficiencies: string[];
+  advantage?: Record<string, string | boolean>;
+  disadvantage?: Record<string, string | boolean>;
+};
+
+// Maps both full ability names and their 3-letter abbreviations to the canonical
+// AbilityScores key, so advantage/disadvantage entries can be written either way.
+const ABILITY_ALIASES: Record<string, keyof AbilityScores> = {
+  str: "strength",
+  strength: "strength",
+  dex: "dexterity",
+  dexterity: "dexterity",
+  con: "constitution",
+  constitution: "constitution",
+  int: "intelligence",
+  intelligence: "intelligence",
+  wis: "wisdom",
+  wisdom: "wisdom",
+  cha: "charisma",
+  charisma: "charisma",
 };
 
 const ABILITY_KEYS: (keyof RawAbilityScores)[] = [
@@ -72,10 +91,33 @@ export function parseAbilityBlock(yamlString: string): RawAbilityBlock {
     },
     bonuses: [],
     proficiencies: [],
+    advantage: {},
+    disadvantage: {},
   };
 
   const parsed = parse(yamlString);
   return Utils.mergeWithDefaults(parsed, def);
+}
+
+/**
+ * Resolves an advantage/disadvantage map (keyed by full ability name or 3-letter
+ * abbreviation, with boolean or template-string values) into a map keyed by the
+ * canonical AbilityScores name. Only truthy entries are retained.
+ */
+function resolveAdvantageMap(
+  map: Record<string, string | boolean> | undefined,
+  context: TemplateContext
+): Partial<Record<keyof AbilityScores, boolean>> {
+  const resolved: Partial<Record<keyof AbilityScores, boolean>> = {};
+  if (!map) return resolved;
+
+  for (const [rawKey, value] of Object.entries(map)) {
+    const ability = ABILITY_ALIASES[rawKey.toLowerCase()];
+    if (!ability) continue;
+    if (coerceBooleanTemplate(value, context)) resolved[ability] = true;
+  }
+
+  return resolved;
 }
 
 /**
@@ -125,6 +167,8 @@ export function resolveAbilityBlock(raw: RawAbilityBlock, frontmatter: Frontmatt
     abilities: resolved,
     bonuses: raw.bonuses,
     proficiencies: raw.proficiencies,
+    advantage: resolveAdvantageMap(raw.advantage, templateContext),
+    disadvantage: resolveAdvantageMap(raw.disadvantage, templateContext),
   };
 }
 

--- a/lib/domains/skills.ts
+++ b/lib/domains/skills.ts
@@ -10,6 +10,8 @@ export function parseSkillsBlock(yamlString: string): SkillsBlock {
     expertise: [],
     half_proficiencies: [],
     bonuses: [],
+    advantage: {},
+    disadvantage: {},
   };
 
   const parsed = parse(yamlString);

--- a/lib/styles/components/ability-cards.css
+++ b/lib/styles/components/ability-cards.css
@@ -71,3 +71,11 @@
     margin-top: var(--dnd-ui-std-gap);
     padding-bottom: var(--dnd-ui-ability-card-padding);
 }
+
+.dnd-ui-ability-modifier-saving.dnd-ui-advantage {
+    color: var(--dnd-ui-color-accent-teal);
+}
+
+.dnd-ui-ability-modifier-saving.dnd-ui-disadvantage {
+    color: var(--dnd-ui-color-accent-red);
+}

--- a/lib/styles/components/skill-card.css
+++ b/lib/styles/components/skill-card.css
@@ -68,6 +68,16 @@
     line-height: 1.1;
 }
 
+.dnd-ui-skill-card.dnd-ui-advantage .dnd-ui-skill-name,
+.dnd-ui-skill-card.dnd-ui-advantage .dnd-ui-skill-value {
+    color: var(--dnd-ui-color-accent-teal);
+}
+
+.dnd-ui-skill-card.dnd-ui-disadvantage .dnd-ui-skill-name,
+.dnd-ui-skill-card.dnd-ui-disadvantage .dnd-ui-skill-value {
+    color: var(--dnd-ui-color-accent-red);
+}
+
 .dnd-ui-skills-values-container {
     display: flex;
     align-items: center;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,8 @@ export type AbilityBlock = {
   abilities: AbilityScores;
   bonuses: GenericBonus[];
   proficiencies: string[];
+  advantage?: Partial<Record<keyof AbilityScores, boolean>>;
+  disadvantage?: Partial<Record<keyof AbilityScores, boolean>>;
 };
 
 // An GenericBonus is an additional property for the ability block
@@ -44,6 +46,8 @@ export type SkillsBlock = {
   expertise: string[];
   half_proficiencies: string[];
   bonuses: SkillsBlockBonus[];
+  advantage?: Record<string, string | boolean>;
+  disadvantage?: Record<string, string | boolean>;
 };
 
 export type SkillsBlockBonus = GenericBonus;
@@ -147,6 +151,8 @@ export type SkillItem = {
   isProficient?: boolean;
   isExpert?: boolean;
   isHalfProficient?: boolean;
+  hasAdvantage?: boolean;
+  hasDisadvantage?: boolean;
   ability: string;
   label: string;
   modifier: number;

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -73,6 +73,22 @@ export function coerceNumericTemplate(processed: string, source: string): number
   return 0;
 }
 
+/**
+ * Coerces a (possibly template-processed) value into a boolean for boolean
+ * component fields such as advantage/disadvantage flags. Accepts native YAML
+ * booleans, and the strings "true"/"false" produced by Handlebars when a
+ * frontmatter boolean is interpolated (e.g. `{{frontmatter.strAdvantage}}`).
+ * Anything else resolves to false. A context is only needed when the value is a
+ * template string; literal booleans are handled without one.
+ */
+export function coerceBooleanTemplate(value: unknown, context?: TemplateContext | null): boolean {
+  if (typeof value === "boolean") return value;
+  if (value == null) return false;
+  const str = String(value);
+  const processed = context && hasTemplateVariables(str) ? processTemplate(str, context) : str;
+  return processed.trim().toLowerCase() === "true";
+}
+
 export function createTemplateContext(el: HTMLElement, fileContext: FileContext): TemplateContext {
   const frontmatter = fileContext.frontmatter();
 

--- a/lib/views/AbilityScoreView.test.ts
+++ b/lib/views/AbilityScoreView.test.ts
@@ -101,4 +101,28 @@ describe("AbilityScoreView", () => {
     // The abilities listener is never registered for this component regardless.
     expect(onAbilitiesChange).not.toHaveBeenCalled();
   });
+
+  it("marks saving throws with advantage/disadvantage flags", async () => {
+    const source = `abilities:
+  strength: 14
+  dexterity: 12
+advantage:
+  str: true
+disadvantage:
+  dexterity: true`;
+    abilityView.render(source, mockElement, mockContext);
+    await addedChild.onload();
+
+    const abilities = addedChild.mount.mock.calls[0][1].abilities;
+    const str = abilities.find((a: any) => a.label === "STR");
+    const dex = abilities.find((a: any) => a.label === "DEX");
+    const con = abilities.find((a: any) => a.label === "CON");
+
+    expect(str.hasAdvantage).toBe(true);
+    expect(str.hasDisadvantage).toBe(false);
+    expect(dex.hasDisadvantage).toBe(true);
+    expect(dex.hasAdvantage).toBe(false);
+    expect(con.hasAdvantage).toBe(false);
+    expect(con.hasDisadvantage).toBe(false);
+  });
 });

--- a/lib/views/AbilityScoreView.ts
+++ b/lib/views/AbilityScoreView.ts
@@ -41,12 +41,18 @@ class AbilityScoreComponent extends TemplateAwareComponent {
 
       const abbreviation = label.substring(0, 3).toUpperCase();
 
+      const abilityKey = key as keyof typeof abilityBlock.abilities;
+      const advantage = abilityBlock.advantage?.[abilityKey] ?? false;
+      const disadvantage = abilityBlock.disadvantage?.[abilityKey] ?? false;
+
       return {
         label: abbreviation,
         total: totalScore,
         modifier: AbilityService.formatModifier(AbilityService.calculateModifier(totalScore)),
         isProficient,
         savingThrow: AbilityService.formatModifier(savingThrowValue),
+        hasAdvantage: advantage && !disadvantage,
+        hasDisadvantage: disadvantage && !advantage,
       };
     });
 

--- a/lib/views/SkillsView.test.ts
+++ b/lib/views/SkillsView.test.ts
@@ -273,4 +273,76 @@ describe("SkillsView", () => {
 
     parseAbilityBlockSpy.mockRestore();
   });
+
+  it("flags advantage and disadvantage on the matching skills", async () => {
+    const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
+    parseAbilityBlockSpy.mockReturnValue({
+      abilities: {
+        strength: 10,
+        dexterity: 10,
+        constitution: 10,
+        intelligence: 10,
+        wisdom: 10,
+        charisma: 10,
+      },
+      bonuses: [],
+      proficiencies: [],
+    });
+
+    const skillsYaml = `proficiencies:
+  - athletics
+advantage:
+  perception: true
+disadvantage:
+  stealth: true`;
+
+    skillsView.render(skillsYaml, mockElement, mockContext);
+    await addedChild.onload();
+
+    const props = addedChild.mount.mock.calls[0][1];
+    const perception = props.items.find((i: any) => i.label.toLowerCase() === "perception");
+    const stealth = props.items.find((i: any) => i.label.toLowerCase() === "stealth");
+    const athletics = props.items.find((i: any) => i.label.toLowerCase() === "athletics");
+
+    expect(perception.hasAdvantage).toBe(true);
+    expect(perception.hasDisadvantage).toBe(false);
+    expect(stealth.hasDisadvantage).toBe(true);
+    expect(stealth.hasAdvantage).toBe(false);
+    // Untouched skills carry neither flag.
+    expect(athletics.hasAdvantage).toBe(false);
+    expect(athletics.hasDisadvantage).toBe(false);
+
+    parseAbilityBlockSpy.mockRestore();
+  });
+
+  it("cancels out a skill flagged as both advantage and disadvantage", async () => {
+    const parseAbilityBlockSpy = vi.spyOn(AbilityService, "parseAbilityBlockFromDocument");
+    parseAbilityBlockSpy.mockReturnValue({
+      abilities: {
+        strength: 10,
+        dexterity: 10,
+        constitution: 10,
+        intelligence: 10,
+        wisdom: 10,
+        charisma: 10,
+      },
+      bonuses: [],
+      proficiencies: [],
+    });
+
+    const skillsYaml = `advantage:
+  perception: true
+disadvantage:
+  perception: true`;
+
+    skillsView.render(skillsYaml, mockElement, mockContext);
+    await addedChild.onload();
+
+    const props = addedChild.mount.mock.calls[0][1];
+    const perception = props.items.find((i: any) => i.label.toLowerCase() === "perception");
+    expect(perception.hasAdvantage).toBe(false);
+    expect(perception.hasDisadvantage).toBe(false);
+
+    parseAbilityBlockSpy.mockRestore();
+  });
 });

--- a/lib/views/SkillsView.ts
+++ b/lib/views/SkillsView.ts
@@ -6,6 +6,7 @@ import * as AbilityService from "lib/domains/abilities";
 import * as SkillsService from "lib/domains/skills";
 import { AbilityBlock, AbilityScores, SkillItem } from "lib/types";
 import { extractFirstCodeBlock } from "../utils/codeblock-extractor";
+import { coerceBooleanTemplate, TemplateContext } from "../utils/template";
 
 export class SkillsView extends BaseView {
   public codeblock = "skills";
@@ -24,7 +25,7 @@ class SkillsComponent extends TemplateAwareComponent {
     const documentText = sectionInfo?.text || "";
     const abilityBlockSrc = extractFirstCodeBlock(documentText, "ability") ?? "";
 
-    this.setupTemplates([this.source, abilityBlockSrc]);
+    const templateContext = this.setupTemplates([this.source, abilityBlockSrc]);
 
     const frontmatter = this.fileContext.frontmatter();
     let abilityBlock: AbilityBlock;
@@ -47,6 +48,12 @@ class SkillsComponent extends TemplateAwareComponent {
     }
 
     const items: SkillItem[] = [];
+
+    const skillFlag = (map: Record<string, string | boolean> | undefined, label: string): boolean => {
+      if (!map) return false;
+      const entry = Object.entries(map).find(([key]) => key.toLowerCase() === label.toLowerCase());
+      return entry ? coerceBooleanTemplate(entry[1], templateContext as TemplateContext | null) : false;
+    };
 
     for (const skill of SkillsService.Skills) {
       const isHalfProficient = skillsBlock.half_proficiencies.some(
@@ -78,6 +85,9 @@ class SkillsComponent extends TemplateAwareComponent {
 
       const abbreviation = skill.ability.substring(0, 3).toUpperCase();
 
+      const advantage = skillFlag(skillsBlock.advantage, skill.label);
+      const disadvantage = skillFlag(skillsBlock.disadvantage, skill.label);
+
       items.push({
         label: skill.label,
         ability: abbreviation,
@@ -85,6 +95,8 @@ class SkillsComponent extends TemplateAwareComponent {
         isProficient,
         isExpert,
         isHalfProficient,
+        hasAdvantage: advantage && !disadvantage,
+        hasDisadvantage: disadvantage && !advantage,
       });
     }
 


### PR DESCRIPTION
## Summary

Closes #67. Adds optional `advantage`/`disadvantage` maps to the `ability` and `skills` blocks so advantage/disadvantage on saving throws and skills can be tracked and seen at a glance.

- Values are booleans — set literally (`strength: true`) or bound to frontmatter (`{{frontmatter.strAdvantage}}`) so a Meta Bind toggle flips them live.
- Advantage colors the save/skill text green, disadvantage red. A save/skill that is both — or neither — is left uncolored (per the issue).
- Ability keys accept full names or 3-letter abbreviations; skill keys are skill names.

## Notes

- `AbilityCards.vue`/`SkillCards.vue` are shared with the raw `ability-cards`/`skill-cards` blocks, so the new props are optional and leave those untouched.
- Live updates rely on the existing template reactivity: a block only re-renders on frontmatter change when its source contains a `{{ }}`, which the meta-bind usage satisfies.