### PR TITLE
fix: checkbox checked state hidden by theme button styles

### DIFF
--- a/lib/styles/components/checkbox.css
+++ b/lib/styles/components/checkbox.css
@@ -7,13 +7,27 @@
     border-radius: 0.2rem;
     cursor: pointer;
     background-color: var(--dnd-ui-color-bg-secondary);
-    transition: background-color 0.1s ease;
     padding: 0;
     margin: 0;
 }
 
+/* The checked fill lives on a pseudo-element because community themes override
+ * button backgrounds with high-specificity rules (e.g. LYT Mode's
+ * `.theme-dark .workspace button { background: ... }`), which would hide a fill
+ * applied to the button itself. Color is routed through --dnd-ui-checkbox-fill
+ * so variants (death saves) can recolor the fill. */
+.dnd-ui-checkbox-button::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background-color: var(--dnd-ui-checkbox-fill, transparent);
+    transition: background-color 0.1s ease;
+}
+
 .dnd-ui-checkbox-button[aria-pressed="true"] {
-    background-color: var(--dnd-ui-color-border-active);
+    --dnd-ui-checkbox-fill: var(--dnd-ui-color-border-active);
 }
 
 .dnd-ui-checkbox-button:focus {

--- a/lib/styles/components/health-card.css
+++ b/lib/styles/components/health-card.css
@@ -178,12 +178,12 @@
 }
 
 /* Death Save Checkbox Styles */
-.dnd-ui-death-save-failure[aria-pressed="true"] {
-    background-color: var(--dnd-ui-color-accent-red) !important;
+.dnd-ui-checkbox-button.dnd-ui-death-save-failure[aria-pressed="true"] {
+    --dnd-ui-checkbox-fill: var(--dnd-ui-color-accent-red);
     border-color: var(--dnd-ui-color-accent-red) !important;
 }
 
-.dnd-ui-death-save-success[aria-pressed="true"] {
-    background-color: var(--dnd-ui-color-accent-teal) !important;
+.dnd-ui-checkbox-button.dnd-ui-death-save-success[aria-pressed="true"] {
+    --dnd-ui-checkbox-fill: var(--dnd-ui-color-accent-teal);
     border-color: var(--dnd-ui-color-accent-teal) !important;
 }


### PR DESCRIPTION
## Summary

Community themes like LYT Mode override workspace button backgrounds with high-specificity `background` shorthand rules, which stomped the `aria-pressed` background fill on consumable/hit-die/initiative checkboxes — state persisted correctly but every box rendered unchecked. The checked fill is now painted on an `::after` pseudo-element (routed through a `--dnd-ui-checkbox-fill` custom property so death saves keep their red/teal colors), which theme button rules can't reach.

Fixes #69