### PR TITLE
feat: add mod template helper for dynamic content

### DIFF
--- a/docs/concepts/dynamic-content.md
+++ b/docs/concepts/dynamic-content.md
@@ -116,9 +116,12 @@ The template system includes several built-in functions for calculations:
 | `subtract` | Subtract two numbers | `{{ subtract 15 3 }}` → 12 |
 | `multiply` | Multiply two numbers | `{{ multiply 4 3 }}` → 12 |
 | `divide` | Divide two numbers | `{{ divide 20 4 }}` → 5 |
+| `mod` | Remainder of a division | `{{ mod 17 5 }}` → 2 |
 | `floor` | Round down to nearest integer | `{{ floor 3.7 }}` → 3 |
 | `ceil` | Round up to nearest integer | `{{ ceil 3.2 }}` → 4 |
 | `round` | Round to nearest integer | `{{ round 3.6 }}` → 4 |
+
+`mod` wraps negative numbers into the positive range, so `{{ mod -1 5 }}` is 4 rather than -1. That keeps it usable for cycling values, where the input can dip below zero.
 :::
 
 ### D&D Specific Functions

--- a/lib/utils/template.test.ts
+++ b/lib/utils/template.test.ts
@@ -44,6 +44,7 @@ describe("template", () => {
       expect(processTemplate("{{subtract 10 4}}", mockContext)).toBe("6");
       expect(processTemplate("{{multiply 3 4}}", mockContext)).toBe("12");
       expect(processTemplate("{{divide 15 3}}", mockContext)).toBe("5");
+      expect(processTemplate("{{mod 17 5}}", mockContext)).toBe("2");
       expect(processTemplate("{{floor 3.7}}", mockContext)).toBe("3");
       expect(processTemplate("{{ceil 3.2}}", mockContext)).toBe("4");
       expect(processTemplate("{{round 3.6}}", mockContext)).toBe("4");
@@ -55,6 +56,13 @@ describe("template", () => {
       expect(processTemplate("{{add abilities.strength frontmatter.proficiency_bonus}}", mockContext)).toBe("17");
       expect(processTemplate("STR modifier: {{modifier abilities.strength}}", mockContext)).toBe("STR modifier: 2");
       expect(processTemplate("CHA modifier: {{modifier abilities.charisma}}", mockContext)).toBe("CHA modifier: -1");
+    });
+
+    it("should wrap negative dividends into the positive range in mod", () => {
+      expect(processTemplate("{{mod -1 5}}", mockContext)).toBe("4");
+      expect(processTemplate("{{mod -5 5}}", mockContext)).toBe("0");
+      expect(processTemplate("{{mod 0 5}}", mockContext)).toBe("0");
+      expect(processTemplate("{{mod (subtract frontmatter.proficiency_bonus 3) 6}}", mockContext)).toBe("5");
     });
 
     it("should return original text when no template variables", () => {

--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -25,6 +25,14 @@ function init() {
   Handlebars.registerHelper("subtract", (a: number, b: number) => a - b);
   Handlebars.registerHelper("multiply", (a: number, b: number) => a * b);
   Handlebars.registerHelper("divide", (a: number, b: number) => a / b);
+  // Floored modulo, so the result always carries the sign of the divisor. Sheet math
+  // is nearly always cycling an index (e.g. stepping a damage die every N levels),
+  // where JS remainder semantics would hand back a negative index.
+  Handlebars.registerHelper("mod", (a: number, b: number) => {
+    const dividend = Number(a);
+    const divisor = Number(b);
+    return dividend - divisor * Math.floor(dividend / divisor);
+  });
   Handlebars.registerHelper("floor", (a: number) => Math.floor(a));
   Handlebars.registerHelper("ceil", (a: number) => Math.ceil(a));
   Handlebars.registerHelper("round", (a: number) => Math.round(a));


### PR DESCRIPTION
Dynamic content templates had no remainder operator. #76 wanted one to cycle an unarmed strike damage die (d4 -> d6 -> ... -> d12 -> 2d6) off a level-derived index, which needs the index to wrap.

`mod` uses floored modulo rather than JS `%`, so the result carries the sign of the divisor and `{{ mod -1 5 }}` is 4 instead of -1. Cycling an index is the reason to reach for this helper at all, and one that dips negative would otherwise fall silently out of range; the two agree for non-negative dividends. Docs note the behavior.

Closes #76
